### PR TITLE
add(attributes): add hooks and data-cy attributes for settings pages

### DIFF
--- a/src/lib/components/inventory/InventoryItem.svelte
+++ b/src/lib/components/inventory/InventoryItem.svelte
@@ -10,16 +10,18 @@
     export let noButton: boolean = false
     export let unequip: boolean = false
     export let empty: boolean = false
+    export let hook: string = ""
 
     const dispatch = createEventDispatcher()
 </script>
 
-<div class="inventory-item {equipped ? 'equipped' : ''}">
+<div data-cy={hook} class="inventory-item {equipped ? 'equipped' : ''}">
     <img src={preview} alt="" />
-    <Text>{name}</Text>
-    <Text muted>{kind}</Text>
+    <Text hook="inventory-item-name">{name}</Text>
+    <Text hook="inventory-item-type" muted>{kind}</Text>
     {#if !noButton}
         <Button
+            hook="inventory-item-button"
             text={equipped ? "Equipped" : "Equip"}
             fill
             on:click={() => {
@@ -35,6 +37,7 @@
     {/if}
     {#if unequip}
         <Button
+            hook="button-unequip-inventory"
             text={empty ? "No Frame" : "Unequip"}
             fill
             on:click={() => {

--- a/src/lib/components/profile/ProfilePicture.svelte
+++ b/src/lib/components/profile/ProfilePicture.svelte
@@ -25,9 +25,9 @@
         <Loader />
     {:else}
         {#if frame && frame.name}
-            <img class="profile-image-frame" src={frame.image} alt="" />
+            <img data-cy="profile-image-frame" class="profile-image-frame" src={frame.image} alt="" />
         {/if}
-        <img class="profile-image" src={image} alt="" />
+        <img data-cy="profile-image" class="profile-image" src={image} alt="" />
     {/if}
     {#if typing}
         <div class="typing-indicator"></div>

--- a/src/lib/components/ui/ColorSwatch.svelte
+++ b/src/lib/components/ui/ColorSwatch.svelte
@@ -8,6 +8,7 @@
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
+    data-cy="color-swatch"
     class="color-swatch tooltip"
     data-tooltip={name}
     on:click={() => {

--- a/src/lib/components/ui/PopupButton.svelte
+++ b/src/lib/components/ui/PopupButton.svelte
@@ -5,13 +5,14 @@
 
     export let open: boolean = false
     export let name: string = "name"
+    export let hook: string = ""
 
     function toggle() {
         open = !open
     }
 </script>
 
-<div class="popup">
+<div class="popup" data-cy={hook}>
     {#if open}
         <Modal on:close={toggle} padded>
             <slot></slot>

--- a/src/routes/settings/inventory/+page.svelte
+++ b/src/routes/settings/inventory/+page.svelte
@@ -16,11 +16,12 @@
 
 <div id="page">
     <div class="equipped">
-        <Label text="Equipped Items" />
+        <Label hook="label-inventory-equipped-items" text="Equipped Items" />
         <div class="items">
             <div class="item">
-                <Label text="Frame" />
+                <Label hook="label-inventory-frame" text="Frame" />
                 <InventoryItem
+                    hook="inventory-profile-picture-frame"
                     equipped={true}
                     kind={InventoryKind.Frame}
                     name={user.profile.photo.frame.name}
@@ -35,10 +36,11 @@
             </div>
         </div>
     </div>
-    <Label text="Frames" />
+    <Label hook="label-inventory-frames" text="Frames" />
     <div class="frames">
         {#each mock_frames as frame}
             <InventoryItem
+                hook="inventory-frame"
                 equipped={user.profile.photo.frame.image === frame.image}
                 kind={InventoryKind.Frame}
                 name={frame.name}
@@ -49,7 +51,7 @@
                 }} />
         {/each}
     </div>
-    <Label text="Profile Overlays" />
+    <Label hook="label-profile-overlays" text="Profile Overlays" />
 </div>
 
 <style lang="scss">

--- a/src/routes/settings/messages/+page.svelte
+++ b/src/routes/settings/messages/+page.svelte
@@ -15,22 +15,25 @@
 </script>
 
 <div id="page">
-    <SettingSection name={$_("settings.messages.convertToEmoji")} description={$_("settings.messages.convertToEmojiDescription")}>
+    <SettingSection hook="section-convert-to-emoji" name={$_("settings.messages.convertToEmoji")} description={$_("settings.messages.convertToEmojiDescription")}>
         <Switch
+            hook="checkbox-convert-to-emoji"
             on={settings ? settings.messaging.convertEmoji : true}
             on:toggle={on => {
                 SettingsStore.update({ ...settings, messaging: { ...settings.messaging, convertEmoji: on.detail } })
             }} />
     </SettingSection>
-    <SettingSection name={$_("settings.messages.markdownSupport")} description={$_("settings.messages.markdownSupportDescription")}>
+    <SettingSection hook="section-markdown-support" name={$_("settings.messages.markdownSupport")} description={$_("settings.messages.markdownSupportDescription")}>
         <Switch
+            hook="checkbox-markdown-support"
             on={settings ? settings.messaging.markdownSupport : true}
             on:toggle={on => {
                 SettingsStore.update({ ...settings, messaging: { ...settings.messaging, markdownSupport: on.detail } })
             }} />
     </SettingSection>
-    <SettingSection name={$_("settings.messages.spamRejection")} description={$_("settings.messages.spamRejectionDescription")}>
+    <SettingSection hook="section-spam-bot-detection" name={$_("settings.messages.spamRejection")} description={$_("settings.messages.spamRejectionDescription")}>
         <Switch
+            hook="checkbox-spam-bot-detection"
             on={settings ? settings.messaging.spamRejection : true}
             on:toggle={on => {
                 SettingsStore.update({ ...settings, messaging: { ...settings.messaging, spamRejection: on.detail } })

--- a/src/routes/settings/preferences/+page.svelte
+++ b/src/routes/settings/preferences/+page.svelte
@@ -92,8 +92,8 @@
             <Icon icon={Shape.FolderOpen} />
         </Button>
     </SettingSection>
-    <SettingSection hook="section-primary-colour" name={$_("settings.preferences.primaryColor")} description={$_("settings.preferences.primaryColorDescription")}>
-        <PopupButton hook="primary-colour-popup-button" name={$_("settings.preferences.pick")}>
+    <SettingSection hook="section-primary-color" name={$_("settings.preferences.primaryColor")} description={$_("settings.preferences.primaryColorDescription")}>
+        <PopupButton hook="primary-color-popup-button" name={$_("settings.preferences.pick")}>
             <ColorPicker textInputModes={["hex"]} isDialog={false} isAlpha={false} bind:hex={hex} />
             <div slot="icon" class="control">
                 <Icon icon={Shape.Eyedropper} />

--- a/src/routes/settings/preferences/+page.svelte
+++ b/src/routes/settings/preferences/+page.svelte
@@ -56,43 +56,44 @@
 </script>
 
 <div id="page">
-    <SettingSection name={$_("settings.preferences.appLanguage")} description={$_("settings.preferences.appLanguageDescription")}>
-        <Select alt options={[{ text: "English (USA)", value: "english" }]} />
+    <SettingSection hook="section-app-language" name={$_("settings.preferences.appLanguage")} description={$_("settings.preferences.appLanguageDescription")}>
+        <Select hook="selector-app-language" alt options={[{ text: "English (USA)", value: "english" }]} />
     </SettingSection>
-    <SettingSection name={$_("settings.preferences.font")} description={$_("settings.preferences.fontDescription")}>
+    <SettingSection hook="section-font" name={$_("settings.preferences.font")} description={$_("settings.preferences.fontDescription")}>
         <Select
+            hook="selector-current-font-{font.toLowerCase()}"
             selected={font}
             options={availableFonts}
             alt
             on:change={v => {
                 UIStore.setFont(v.detail)
             }} />
-        <Button icon appearance={Appearance.Alt} tooltip={$_("generic.openFolder")}>
+        <Button hook="button-font-open-folder" icon appearance={Appearance.Alt} tooltip={$_("generic.openFolder")}>
             <Icon icon={Shape.FolderOpen} />
         </Button>
     </SettingSection>
-    <SettingSection name={$_("settings.preferences.fontScaling")} description={$_("settings.preferences.fontScalingDescription")}>
-        <Button icon appearance={Appearance.Alt} on:click={_ => UIStore.decreaseFontSize()}>
+    <SettingSection hook="section-font-scaling" name={$_("settings.preferences.fontScaling")} description={$_("settings.preferences.fontScalingDescription")}>
+        <Button hook="button-font-scaling-decrease" icon appearance={Appearance.Alt} on:click={_ => UIStore.decreaseFontSize()}>
             <Icon icon={Shape.Minus} />
         </Button>
         <div class="font-size">
-            <Input alt value={fontSize.toFixed(2).toString()} centered />
+            <Input hook="input-font-scaling" alt value={fontSize.toFixed(2).toString()} centered />
         </div>
-        <Button icon appearance={Appearance.Alt} on:click={_ => UIStore.increaseFontSize()}>
+        <Button hook="button-font-scaling-increase" icon appearance={Appearance.Alt} on:click={_ => UIStore.increaseFontSize()}>
             <Icon icon={Shape.Plus} />
         </Button>
     </SettingSection>
-    <SettingSection name={$_("settings.preferences.theme")} description={$_("settings.preferences.themeDescription")}>
-        <Button icon appearance={Appearance.Alt}>
+    <SettingSection hook="section-theme" name={$_("settings.preferences.theme")} description={$_("settings.preferences.themeDescription")}>
+        <Button hook="button-theme-moon" icon appearance={Appearance.Alt}>
             <Icon icon={Shape.Moon} />
         </Button>
-        <Select alt options={[{ text: "Default", value: "default" }]} />
-        <Button icon appearance={Appearance.Alt}>
+        <Select hook="selector-theme" alt options={[{ text: "Default", value: "default" }]} />
+        <Button hook="button-theme-open-folder" icon appearance={Appearance.Alt}>
             <Icon icon={Shape.FolderOpen} />
         </Button>
     </SettingSection>
-    <SettingSection name={$_("settings.preferences.primaryColor")} description={$_("settings.preferences.primaryColorDescription")}>
-        <PopupButton name={$_("settings.preferences.pick")}>
+    <SettingSection hook="section-primary-colour" name={$_("settings.preferences.primaryColor")} description={$_("settings.preferences.primaryColorDescription")}>
+        <PopupButton hook="primary-colour-popup-button" name={$_("settings.preferences.pick")}>
             <ColorPicker textInputModes={["hex"]} isDialog={false} isAlpha={false} bind:hex={hex} />
             <div slot="icon" class="control">
                 <Icon icon={Shape.Eyedropper} />
@@ -110,8 +111,9 @@
         <ColorSwatch name="Apple Valley" color="#0a8560" />
         <ColorSwatch name="Pencil Lead" color="#3c424d" />
     </SettingSection>
-    <SettingSection name={$_("settings.preferences.customCss")} description={$_("settings.preferences.customCssDescription")} fullWidth>
+    <SettingSection hook="section-custom-css" name={$_("settings.preferences.customCss")} description={$_("settings.preferences.customCssDescription")} fullWidth>
         <textarea
+            data-cy="text-area-custom-css"
             bind:value={cssOverride}
             on:change={_ => {
                 UIStore.setCssOverride(cssOverride)


### PR DESCRIPTION
### What this PR does 📖

- Adding hook property for test attributes on InventoryItems, ProfilePicture, ColorSwatch, PopUpButton kit elements
- Adding data-cy attributes for elements on Settings Inventory, Settings Customization and Settings Mesages

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
