### PR TITLE
update(attribute): update test attribute for context menu options

### DIFF
--- a/src/lib/components/ui/ContextMenu.svelte
+++ b/src/lib/components/ui/ContextMenu.svelte
@@ -53,7 +53,7 @@
     }
 
     function handleItemClick(e: MouseEvent, item: ContextItem) {
-        e.stopPropagation()  // Prevent clickoutside from closing the menu
+        e.stopPropagation() // Prevent clickoutside from closing the menu
         console.log("Clicked", item.text)
         item.onClick()
         onClose(e)
@@ -67,12 +67,7 @@
     <div id="context-menu" data-cy={hook} bind:this={context} use:clickoutside on:clickoutside={onClose} style={`left: ${coords[0]}px; top: ${coords[1]}px;`}>
         <slot name="items" close={onClose}></slot>
         {#each items as item}
-            <Button
-                hook={item.text.toLowerCase().replace(/\s+/g, "-") + item.id}
-                class="item"
-                appearance={item.appearance === Appearance.Default ? Appearance.Transparent : item.appearance}
-                text={item.text}
-                on:click={e => handleItemClick(e, item)}>
+            <Button hook={item.id} class="item" appearance={item.appearance === Appearance.Default ? Appearance.Transparent : item.appearance} text={item.text} on:click={e => handleItemClick(e, item)}>
                 <Icon icon={item.icon} />
             </Button>
         {/each}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Cleaning up the hook attribute for context menu options to use item.id instead of item.name converted to lower case and using regex to add separators. No need to do that since we can just simply use item.id for it

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
