### PR TITLE
feat(wasm): impl relay address config settings

### DIFF
--- a/src/lib/components/ui/RelaySelector.svelte
+++ b/src/lib/components/ui/RelaySelector.svelte
@@ -1,0 +1,261 @@
+<script lang="ts">
+    import { Icon, Text, Label, Button, Input } from "$lib/elements"
+    import { Appearance, Shape, Size } from "$lib/enums"
+    import { RelayStore, type RelayState } from "$lib/state/wasm/relays"
+    import Modal from "$lib/components/ui/Modal.svelte"
+    import { WarpStore } from "$lib/wasm/WarpStore"
+    import { get } from "svelte/store"
+    import { _ } from "svelte-i18n"
+
+    type onClose = () => {}
+    export let close: onClose | undefined = undefined
+    let tesseract = get(WarpStore.warp.tesseract)
+    let changed = false
+    let adding: boolean = false
+    let editing: string | undefined = undefined
+    let relaysBack: { [key: string]: RelayState } = get(RelayStore.state)
+    let relays = { ...relaysBack }
+    RelayStore.state.subscribe(s => {
+        relaysBack = s
+        relays = { ...s }
+    })
+
+    let nameToAdd: string = ""
+    let relayToAdd: string = ""
+
+    function saveAndUpdate() {
+        RelayStore.update(relays)
+        if (tesseract && tesseract !== null) {
+            WarpStore.initWarpInstances(
+                tesseract,
+                Object.values(relays)
+                    .filter(r => r.active)
+                    .map(r => r.address)
+            )
+        }
+        changed = false
+    }
+
+    function add() {
+        if (verifyName(nameToAdd) && verifyAddress(relayToAdd)) {
+            let active = true
+            if (editing) {
+                active = relays[editing].active
+                delete relays[editing]
+            }
+            relays[nameToAdd] = {
+                active: active,
+                address: relayToAdd,
+            }
+            changed = true
+            nameToAdd = ""
+            relayToAdd = ""
+            adding = false
+            editing = undefined
+        }
+    }
+
+    function toggleRelay(name: string) {
+        relays[name].active = !relays[name].active
+        changed = true
+    }
+
+    function deleteRelay(name: string) {
+        delete relays[name]
+        relays = relays // Trigger update
+        changed = true
+    }
+
+    function revert() {
+        relays = { ...relaysBack }
+        changed = false
+    }
+
+    function verifyName(name: string) {
+        return (editing === name || !(name in relays)) && name !== ""
+    }
+
+    function verifyAddress(address: string) {
+        return address !== "" && !address.includes(" ")
+    }
+</script>
+
+<div class="relay-selector">
+    <Label text={$_("settings.relay.title")} />
+    <div class="relay-content">
+        {#if adding || editing}
+            <Modal>
+                <div class="relay-add-modal">
+                    <Label text={$_("settings.relay.name")} />
+                    <Input bind:value={nameToAdd}></Input>
+                    {#if nameToAdd !== "" && !verifyName(nameToAdd)}
+                        <div class="error">{$_("settings.relay.name_exist")}</div>
+                    {/if}
+                    <Label text={$_("settings.relay.address")} />
+
+                    <Input bind:value={relayToAdd} on:enter={add}></Input>
+                    {#if relayToAdd !== "" && !verifyAddress(relayToAdd)}
+                        <div class="error">{$_("settings.relay.invalid_address")}</div>
+                    {/if}
+                    <Button
+                        class="cancel"
+                        appearance={Appearance.Alt}
+                        on:click={_ => {
+                            nameToAdd = ""
+                            relayToAdd = ""
+                            adding = false
+                            editing = undefined
+                        }}>
+                        <Icon icon={Shape.UTurn} />
+                    </Button>
+                    <Button class="save" appearance={Appearance.Alt} on:click={add}>
+                        <Icon icon={Shape.CheckMark} />
+                    </Button>
+                </div>
+            </Modal>
+        {/if}
+        {#each Object.entries(relays) as [name, relay]}
+            <div class="relay-entry">
+                <div class="relay-name" data-tooltip={relay.address}>
+                    <Text>{name}</Text>
+                </div>
+                <Button class="relay-toggle" small appearance={!relay.active ? Appearance.Alt : Appearance.Success} on:click={_ => toggleRelay(name)}>
+                    <Icon icon={Shape.CheckMark} />
+                </Button>
+                <Button
+                    class="relay-edit"
+                    small
+                    appearance={Appearance.Alt}
+                    on:click={_ => {
+                        editing = name
+                        nameToAdd = name
+                        relayToAdd = relay.address
+                    }}>
+                    <Icon icon={Shape.Preferences} />
+                </Button>
+                <Button class="relay-delete" small appearance={Appearance.Alt} on:click={_ => deleteRelay(name)}>
+                    <Icon icon={Shape.Trash} />
+                </Button>
+            </div>
+        {/each}
+        {#if Object.entries(relays).length > 0}
+            <hr />
+        {/if}
+        {#if changed}
+            <div>
+                <Text size={Size.Smaller}>{$_("generic.pending_changes")}</Text>
+            </div>
+        {/if}
+
+        <div class="controls">
+            <Button
+                class="relay-add"
+                appearance={Appearance.Alt}
+                on:click={_ => {
+                    adding = true
+                }}>
+                <Icon icon={Shape.Plus} />
+            </Button>
+            <div class="filling"></div>
+            <Button class="revert" appearance={Appearance.Alt} tooltip={$_("generic.undo")} on:click={revert}>
+                <Icon icon={Shape.UTurn} />
+            </Button>
+            <Button
+                class="relay-save"
+                appearance={Appearance.Alt}
+                tooltip={$_("generic.save")}
+                on:click={_ => {
+                    if (changed) {
+                        saveAndUpdate()
+                    }
+                }}>
+                <Icon icon={Shape.CheckMark} />
+            </Button>
+            {#if close}
+                <Button
+                    class="cancel"
+                    appearance={Appearance.Alt}
+                    tooltip={$_("generic.cancel")}
+                    on:click={_ => {
+                        close()
+                    }}>
+                    <Icon icon={Shape.NoSymbol} />
+                </Button>
+            {/if}
+        </div>
+    </div>
+</div>
+
+<style lang="scss">
+    .relay-selector {
+        width: 100%;
+        // padding: var(--padding);
+        display: flex;
+        flex-direction: column;
+        gap: var(--gap);
+
+        :global(.title) {
+            color: var(--color-muted);
+            padding-bottom: var(--padding-less);
+        }
+
+        hr {
+            width: 100%;
+            height: 0;
+        }
+        .relay-entry {
+            display: flex;
+            gap: var(--gap);
+            .relay-name {
+                width: 100%;
+                position: relative;
+                &:before {
+                    content: attr(data-tooltip);
+                    position: absolute;
+                    bottom: calc(100% + var(--gap));
+                    white-space: nowrap;
+                    width: fit-content;
+                    padding: var(--padding-minimal) var(--padding-less);
+                    border-radius: var(--border-radius-minimal);
+                    border: var(--border-width) solid var(--border-color);
+                    color: var(--color);
+                    font-size: var(--font-size-smaller);
+                    text-align: center;
+                    opacity: 0;
+                    pointer-events: none;
+                    z-index: 2;
+                    transition: all var(--animation-speed);
+                    background-color: var(--opaque-color);
+                    backdrop-filter: blur(var(--blur-radius));
+                    -webkit-backdrop-filter: blur(var(--blur-radius));
+                }
+                &:hover:before {
+                    opacity: 1;
+                }
+            }
+        }
+
+        .controls {
+            display: flex;
+            gap: var(--gap-less);
+        }
+
+        .filling {
+            width: 100%;
+        }
+
+        .error {
+            font-size: var(--font-size-smallest);
+            color: var(--error-color);
+        }
+
+        .relay-add-modal {
+            background-color: var(--alt-color);
+            display: flex;
+            flex-direction: column;
+            gap: var(--gap-less);
+            padding: var(--padding);
+            border-radius: var(--border-radius);
+        }
+    }
+</style>

--- a/src/lib/elements/Button.svelte
+++ b/src/lib/elements/Button.svelte
@@ -100,7 +100,6 @@
             position: relative;
 
             &:before {
-                display: none;
                 content: attr(data-tooltip);
                 position: absolute;
                 bottom: calc(100% + var(--gap));

--- a/src/lib/lang/index.ts
+++ b/src/lib/lang/index.ts
@@ -11,6 +11,7 @@ export function initLocale() {
                 remove: "Remove",
                 save: "Save",
                 cancel: "Cancel",
+                undo: "Undo",
                 copy: "Copy",
                 loading: "Loading",
                 username: "Username",
@@ -24,6 +25,7 @@ export function initLocale() {
                 profiles: "Profiles",
                 users: "Users",
                 groups: "Groups",
+                pending_changes: "Unsaved changes",
             },
             market: {
                 market: "Marketplace",
@@ -175,6 +177,13 @@ export function initLocale() {
                 licenses: {
                     description: "Both code and icons are under the MIT license.",
                     view: "View License",
+                },
+                relay: {
+                    title: "Relay config",
+                    name: "Relay name",
+                    address: "Address",
+                    name_exist: "Name already exist",
+                    invalid_address: "Invalid address",
                 },
             },
         },

--- a/src/lib/state/wasm/relays.ts
+++ b/src/lib/state/wasm/relays.ts
@@ -1,0 +1,40 @@
+import { get, type Writable } from "svelte/store"
+import { createPersistentState } from ".."
+
+export interface RelayState {
+    address: string
+    active: boolean
+}
+
+class Store {
+    state: Writable<{ [key: string]: RelayState }>
+
+    constructor() {
+        this.state = createPersistentState("uplink.wasm.relays", {})
+    }
+
+    getRelay(name: string): RelayState | undefined {
+        let relays = get(this.state)
+        return relays[name]
+    }
+
+    saveNewRelay(name: string, address: string) {
+        let relays = get(this.state)
+        relays[name] = { address, active: false }
+        this.state.set(relays)
+    }
+
+    deleteRelays(names: string[]) {
+        let relays = get(this.state)
+        for (let name of names) {
+            delete relays[name]
+        }
+        this.state.set(relays)
+    }
+
+    update(value: { [key: string]: RelayState }) {
+        this.state.set(value)
+    }
+}
+
+export const RelayStore = new Store()

--- a/src/lib/wasm/WarpStore.ts
+++ b/src/lib/wasm/WarpStore.ts
@@ -7,31 +7,34 @@ class Store {
 
     constructor() {
         this.warp = {
-            tesseract: createPersistentState('warp.tesseract', null),
-            multipass: createPersistentState('warp.multipass', null),
-            raygun: createPersistentState('warp.raygun', null),
-            constellation: createPersistentState('warp.constellation', null),
+            tesseract: createPersistentState("warp.tesseract", null),
+            multipass: createPersistentState("warp.multipass", null),
+            raygun: createPersistentState("warp.raygun", null),
+            constellation: createPersistentState("warp.constellation", null),
         }
     }
 
-    async initWarpInstances(
-        tesseract: wasm.Tesseract
-    ) {
+    async initWarpInstances(tesseract: wasm.Tesseract, addresses?: string[]) {
         await init()
-        // HACK: Replace 'your-relay-address-here' with your relay address
-        // This is a temporary solution 
-        // Run this command on Warp repo to start a relay server: 
-        // cargo run --bin relay-server --release -- --listen-addr /ip4/127.0.0.1/tcp/4444/ws --keyfile /tmp/key.bin
-        // Uncomment code below to use your local relay server
-        // And comment line 30
-        let warp_instance = await new wasm.WarpIpfs(wasm.Config.minimal_with_relay([
-            '/ip4/127.0.0.1/tcp/4444/ws/p2p/12D3KooWPYK5aNLqdyXh9RiCsv1Gm8vpsJnNjp6DzBhe5Z7wT6gx'
-        ]), tesseract) as wasm.WarpInstance
-        // let warp_instance = await new wasm.WarpIpfs(wasm.Config.minimal_testing(), tesseract) as wasm.WarpInstance
+        let warp_instance = await this.createIpfs(tesseract, addresses)
         this.warp.tesseract.set(tesseract)
         this.warp.multipass.set(warp_instance.multipass)
         this.warp.raygun.set(warp_instance.raygun)
         this.warp.constellation.set(warp_instance.constellation)
+    }
+
+    private async createIpfs(tesseract: wasm.Tesseract, addresses?: string[]) {
+        if (addresses && addresses.length > 0) {
+            return (await new wasm.WarpIpfs(wasm.Config.minimal_with_relay(addresses), tesseract)) as wasm.WarpInstance
+        }
+        // HACK: Replace 'your-relay-address-here' with your relay address
+        // This is a temporary solution
+        // Run this command on Warp repo to start a relay server:
+        // cargo run --bin relay-server --release -- --listen-addr /ip4/127.0.0.1/tcp/4444/ws --keyfile /tmp/key.bin
+        // Uncomment code below to use your local relay server
+        // And comment line 52
+        //return (await new wasm.WarpIpfs(wasm.Config.minimal_with_relay(["your-relay-address"]), tesseract)) as wasm.WarpInstance
+        return (await new wasm.WarpIpfs(wasm.Config.minimal_testing(), tesseract)) as wasm.WarpInstance
     }
 }
 

--- a/src/routes/settings/developer/+page.svelte
+++ b/src/routes/settings/developer/+page.svelte
@@ -9,6 +9,7 @@
     import { ConversationStore } from "$lib/state/conversation"
     import { InventoryStore } from "$lib/state/inventory"
     import { goto } from "$app/navigation"
+    import RelaySelector from "$lib/components/ui/RelaySelector.svelte"
 
     initLocale()
 </script>
@@ -37,6 +38,7 @@
     <SettingSection name="Test Voice" description="Dev Voice">
         <Button appearance={Appearance.Alt} on:click={_ => goto("/developer/debug/voice")}>Voice Dev</Button>
     </SettingSection>
+    <RelaySelector />
 </div>
 
 <style lang="scss">
@@ -46,5 +48,9 @@
         margin: 0;
         flex: 1;
         gap: var(--gap);
+        :global(.relay-selector > .relay-content) {
+            background-color: var(--alt-color);
+            padding: var(--padding);
+        }
     }
 </style>


### PR DESCRIPTION
### What this PR does 📖

-Implements a setting to configure which relay address to connect to.
- The config is in the developer settings page and also at the unlock page (to already launch the app with a specific relay address)
- A list is provided that contains a mapping of a name and an address.
  - The name can be freely chosen but needs to be unique.
  - The address refers to the relay address to connect to.
  - The list is saved to persist across sessions
  - The user can turn the connection to an address on/off

<img width="887" alt="Screenshot 2024-06-10 at 19 28 17" src="https://github.com/Satellite-im/UplinkWeb/assets/34157027/bae1e2f2-a569-4e5b-8405-90d8048f59fc">
<img width="878" alt="Screenshot 2024-06-10 at 19 28 23" src="https://github.com/Satellite-im/UplinkWeb/assets/34157027/a879d9d6-1007-47b1-a932-c119cba0afb7">
