### PR TITLE
chore(lint): add svelte-check to find errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
                 "prettier-plugin-svelte": "^3.2.3",
                 "sass": "^1.71.0",
                 "svelte": "^4.2.17",
-                "svelte-check": "^3.6.0",
+                "svelte-check": "^3.8.0",
                 "svelte-preprocess": "^5.1.3",
                 "typescript": "^5.4.5",
                 "vite": "^5.0.3"
@@ -6808,9 +6808,9 @@
             }
         },
         "node_modules/svelte-check": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.7.1.tgz",
-            "integrity": "sha512-U4uJoLCzmz2o2U33c7mPDJNhRYX/DNFV11XTUDlFxaKLsO7P+40gvJHMPpoRfa24jqZfST4/G9fGNcUGMO8NAQ==",
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.8.0.tgz",
+            "integrity": "sha512-7Nxn+3X97oIvMzYJ7t27w00qUf1Y52irE2RU2dQAd5PyvfGp4E7NLhFKVhb6PV2fx7dCRMpNKDIuazmGthjpSQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.17",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "preview": "vite preview --host 0.0.0.0 --port 80",
         "check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
-        "format": "prettier --write 'src/**/*.{css,html,js,svelte,ts}'"
+        "format": "prettier --write 'src/**/*.{css,html,js,svelte,ts}'",
+        "lint": "npm run format && npm run check"
     },
     "devDependencies": {
         "@castlenine/vite-remove-attribute": "^1.0.2",
@@ -24,7 +25,7 @@
         "prettier-plugin-svelte": "^3.2.3",
         "sass": "^1.71.0",
         "svelte": "^4.2.17",
-        "svelte-check": "^3.6.0",
+        "svelte-check": "^3.8.0",
         "svelte-preprocess": "^5.1.3",
         "typescript": "^5.4.5",
         "vite": "^5.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4066,10 +4066,10 @@ svelte-awesome-slider@^1.1.0:
   resolved "https://registry.npmjs.org/svelte-awesome-slider/-/svelte-awesome-slider-1.1.0.tgz"
   integrity sha512-MgY6ZdBON42HVZqNWNjq2HOgyDlC35q0TNbV/YO1l1/bcb5yhM8EE97h1AJ/7F6t6sLzXhQ3qPf5nGyCdDSnCg==
 
-svelte-check@^3.6.0:
-  version "3.7.1"
-  resolved "https://registry.npmjs.org/svelte-check/-/svelte-check-3.7.1.tgz"
-  integrity sha512-U4uJoLCzmz2o2U33c7mPDJNhRYX/DNFV11XTUDlFxaKLsO7P+40gvJHMPpoRfa24jqZfST4/G9fGNcUGMO8NAQ==
+svelte-check@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.npmjs.org/svelte-check/-/svelte-check-3.8.0.tgz"
+  integrity sha512-7Nxn+3X97oIvMzYJ7t27w00qUf1Y52irE2RU2dQAd5PyvfGp4E7NLhFKVhb6PV2fx7dCRMpNKDIuazmGthjpSQ==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.17"
     chokidar "^3.4.1"


### PR DESCRIPTION
### What this PR does 📖

- Adding svelte-check to find errors and warnings in the code
- Errors found are not addressed on this PR, the goal is once that there are no errors we can add a pre-commit hook using  this check
- You can do `npm run check` to run svelte-check which will show an output like this:

![image](https://github.com/Satellite-im/UplinkWeb/assets/35935591/7adbb60b-bb29-425a-a4a4-511b31335604)

- Also, you can now run `npm run lint` to run prettier and then svelte-check

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
