### PR TITLE
chore(fix): fix error on empty status message

### DIFF
--- a/src/lib/wasm/MultipassStore.ts
+++ b/src/lib/wasm/MultipassStore.ts
@@ -33,6 +33,10 @@ class MultipassStore {
             try {
                 await multipass.create_identity(username, passphrase);
                 if (statusMessage.length > 0) {
+                    if (statusMessage.length > 512) {
+                        get(Store.state.logger).warn(`Status message len is ${statusMessage.length}. Max is 512. Truncating to fit.`)
+                        statusMessage = statusMessage.substring(0, 512)
+                    }
                     await this.updateStatusMessage(statusMessage);
                 }
                 const identity = get(this.identity);

--- a/src/lib/wasm/MultipassStore.ts
+++ b/src/lib/wasm/MultipassStore.ts
@@ -32,7 +32,9 @@ class MultipassStore {
         if (multipass) {
             try {
                 await multipass.create_identity(username, passphrase);
-                await this.updateStatusMessage(statusMessage);
+                if (statusMessage.length > 0) {
+                    await this.updateStatusMessage(statusMessage);
+                }
                 const identity = get(this.identity);
                 get(Store.state.logger).info(`New account created. \n
                 Username: ${identity?.username()} \n 


### PR DESCRIPTION
### What this PR does 📖

Resolves this error in the console which appears on account creation:

```
[ERROR] (9:21:52 AM):  Error creating identity: Error: Length for 'status' is invalid. Current length: 0. Minimum Length: Some(1), Maximum: Some(512)
```

### Which issue(s) this PR fixes 🔨

- Resolve #

### Special notes for reviewers 🗒️

### Additional comments 🎤
