### PR TITLE
commit warp-wasm 1.2.5 lock files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "three": "^0.163.0",
                 "uuid": "^9.0.1",
                 "vite-plugin-node-polyfills": "^0.21.0",
-                "warp-wasm": "^1.2.4"
+                "warp-wasm": "^1.2.5"
             },
             "devDependencies": {
                 "@castlenine/vite-remove-attribute": "^1.0.2",
@@ -7707,9 +7707,10 @@
             "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
         },
         "node_modules/warp-wasm": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/warp-wasm/-/warp-wasm-1.2.4.tgz",
-            "integrity": "sha512-E7DHoZ3z1sO5DQ0dMVpOrCPLZFyBcKs38Ul+Rr6/PeIz7lYE5wMPQ25dDzimedgiTfSX9x/Vn0Nl0RTwLyx6dg=="
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/warp-wasm/-/warp-wasm-1.2.5.tgz",
+            "integrity": "sha512-NCBXJp9ZUv9AFUZwWo+xV2+EczDgZUMRQ1ZXRdp8UXD4G9vFwCITix3VJ5DFm8tb7yddnFjdX5k0cJxFg16esw==",
+            "license": "MIT"
         },
         "node_modules/whatwg-encoding": {
             "version": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4338,10 +4338,10 @@ w3c-keyname@^2.2.4:
   resolved "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz"
   integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
-warp-wasm@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/warp-wasm/-/warp-wasm-1.2.4.tgz"
-  integrity sha512-E7DHoZ3z1sO5DQ0dMVpOrCPLZFyBcKs38Ul+Rr6/PeIz7lYE5wMPQ25dDzimedgiTfSX9x/Vn0Nl0RTwLyx6dg==
+warp-wasm@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/warp-wasm/-/warp-wasm-1.2.5.tgz"
+  integrity sha512-NCBXJp9ZUv9AFUZwWo+xV2+EczDgZUMRQ1ZXRdp8UXD4G9vFwCITix3VJ5DFm8tb7yddnFjdX5k0cJxFg16esw==
 
 whatwg-encoding@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### What this PR does 📖

Commits `warp-wasm 1.2.5` lock files (they were still stuck on an old version) 
This might have caused issues for some people with the relay (friend request not being received) if they didn't do `npm install` to generate these. Because that would mean they were still on an old version while they thought they were on 1.2.5

### Which issue(s) this PR fixes 🔨

- Resolve #

### Special notes for reviewers 🗒️

### Additional comments 🎤
