### PR TITLE
fix warp functions missing on refresh

### DIFF
--- a/src/lib/wasm/WarpStore.ts
+++ b/src/lib/wasm/WarpStore.ts
@@ -1,7 +1,6 @@
-import { createPersistentState } from "$lib/state/db/persistedState";
 import init, * as wasm from "warp-wasm";
 import type { IWarp } from "./IWarp";
-import { get } from "svelte/store";
+import { get, writable } from "svelte/store";
 
 /**
  * Class representing the Store, which manages the state and interactions with Warp instances.
@@ -14,10 +13,10 @@ class Store {
      */
     constructor() {
         this.warp = {
-            tesseract: createPersistentState("warp.tesseract", null),
-            multipass: createPersistentState("warp.multipass", null),
-            raygun: createPersistentState("warp.raygun", null),
-            constellation: createPersistentState("warp.constellation", null),
+            tesseract: writable<wasm.Tesseract | null>(null),
+            multipass: writable<wasm.MultiPassBox | null>(null),
+            raygun: writable<wasm.RayGunBox | null>(null),
+            constellation: writable<wasm.ConstellationBox | null>(null),
         }
     }
 


### PR DESCRIPTION
### What this PR does 📖

Fixes the errors like `raygun.raygun_subscribe is not a function` whenever web app was refreshed. This in part was due to `createPersistentState` attempting to persist the instances. 

These wasm instances should not be persisted as they only contain references to locations in wasm memory which would be different every time we refresh. Removing the `createPersistentState` here allows them to be correctly created.

### Which issue(s) this PR fixes 🔨

- Resolve #

### Special notes for reviewers 🗒️

### Additional comments 🎤
