### PR TITLE
fix(wasm): enable warp persistence

### DIFF
--- a/src/lib/wasm/WarpStore.ts
+++ b/src/lib/wasm/WarpStore.ts
@@ -61,7 +61,7 @@ class Store {
         // Uncomment code below to use your local relay server - line 63
         // And comment line 64
         // return (await new wasm.WarpIpfs(wasm.Config.minimal_with_relay(["your-relay-address"]), tesseract)) as wasm.WarpInstance;
-        return (await new wasm.WarpIpfs(wasm.Config.minimal_testing())) as wasm.WarpInstance;
+        return (await new wasm.WarpIpfs(wasm.Config.minimal_basic())) as wasm.WarpInstance;
     }
 }
 


### PR DESCRIPTION
### What this PR does 📖

- `minimal_testing` is only in-memory. That's why we couldn't log back into an existing account. `minimal_basic` enables persistence
- Note that there are errors solved by #114 that make it easier to test this PR if it gets merged first.

### Which issue(s) this PR fixes 🔨

- Resolve #

### Special notes for reviewers 🗒️

### Additional comments 🎤
