### PR TITLE
update(buttons): fix open websites buttons and made in flags

### DIFF
--- a/src/routes/settings/about/+page.svelte
+++ b/src/routes/settings/about/+page.svelte
@@ -29,17 +29,17 @@
         </Button>
     </SettingSection>
     <SettingSection hook="section-about-website" name="Website" description="Open a new browser window to our official website.">
-        <Button hook="button-open-website" text="Open Website" appearance={Appearance.Alt}>
+        <Button hook="button-open-website" text="Open Website" appearance={Appearance.Alt} on:click={() => window.open("https://satellite.im/", "_blank")}>
             <Icon icon={Shape.Globe} />
         </Button>
     </SettingSection>
     <SettingSection hook="section-about-open-source-code" name="Open Source Code" description="Open a new browser window to our open source repository.">
-        <Button hook="button-open-source-code" text="Open Source Code" appearance={Appearance.Alt}>
+        <Button hook="button-open-source-code" text="Open Source Code" appearance={Appearance.Alt} on:click={() => window.open("https://github.com/Satellite-im", "_blank")}>
             <Icon icon={Shape.Code} />
         </Button>
     </SettingSection>
     <SettingSection hook="section-about-made-in" name="Made In" description="Our team is all over the world with different backgrounds and different day-to-day lives all working on a common goal to build this app.">
-        <div data-cy="about-made-in-flags" class="flags">🇺🇸 🇮🇹 🇩🇪 🇵🇹 🇧🇷 🇺🇦 🇧🇾 🇯🇵 🇦🇺 🇮🇩</div>
+        <div data-cy="about-made-in-flags" class="flags">🇺🇸 🇮🇹 🇩🇪 🇵🇹 🇧🇷 🇺🇦 🇧🇾 🇯🇵 🇦🇺 🇮🇩 🇲🇽 🇨🇦</div>
     </SettingSection>
     <SettingSection hook="section-about-dev-mode" name="DevMode" description="Click 10 times to enable developer settings.">
         <Button hook="button-about-dev-mode" on:click={_ => increment()} icon appearance={Appearance.Alt}>

--- a/src/routes/settings/licenses/+page.svelte
+++ b/src/routes/settings/licenses/+page.svelte
@@ -10,7 +10,7 @@
 
 <div id="page">
     <SettingSection hook="section-licenses-uplink" name={$_("generic.uplink")} description={$_("settings.licenses.description")}>
-        <Button hook="button-view-license" text={$_("settings.licenses.view")} appearance={Appearance.Alt}>
+        <Button hook="button-view-license" text={$_("settings.licenses.view")} appearance={Appearance.Alt} on:click={() => window.open("https://github.com/Satellite-im/UplinkWeb/blob/dev/LICENSE-MIT", "_blank")}>
             <Icon icon={Shape.Document} />
         </Button>
     </SettingSection>


### PR DESCRIPTION
### What this PR does 📖

- Fixes open website button on about page, now opening a new tab redirecting to: https://satellite.im/
- Fixes open source code button on about page, now opening a new tab redirecting to: https://github.com/Satellite-im
- Fixes open license button on licenses page, now opening a new tab redirecting to: https://github.com/Satellite-im/UplinkWeb/blob/dev/LICENSE-MIT
- Fixes Made In flags in about page, now showing Mexico and Canada flags

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
