### PR TITLE
fix(Input): Clear input when rich option is enabled and we click on send button

### DIFF
--- a/src/lib/elements/Input/Input.svelte
+++ b/src/lib/elements/Input/Input.svelte
@@ -59,10 +59,11 @@
     $: value = $writableValue
 
     let onsend: any[] = []
+    let editor: MarkdownEditor
     if (rich) {
         onMount(() => {
             if (autoFocus) input.focus()
-            let editor = new MarkdownEditor(input, {
+            editor = new MarkdownEditor(input, {
                 keys: MarkdownEditor.ChatEditorKeys(() => send()),
                 only_autolink: true,
                 extensions: [EditorView.editorAttributes.of({ class: input.classList.toString() })],
@@ -83,6 +84,10 @@
                 editor.value("")
             })
         })
+    }
+
+    $: if (rich && editor) {
+        editor.value($writableValue);
     }
 
     export { clazz as class }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- ChatBar has not been cleared after we send message using send button, just with enter. So now, when we hit a button, it will send message and clear input. This was happening because rich variable that is true on chatbar, so code just guarantee that will be updated as well when value has changed.

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
