### PR TITLE
fix(Multipass): Guarantee name not come as undefiend on toast message when receive a friend request

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,3 +2,6 @@ export const DEFAULT_CDN = {
     name: "Default CA_TO-1",
     address: "https://cdn.deepspaceshipping.co",
 }
+
+export const RETRY_DELAY: number = 1000 // ms
+export const MAX_RETRY_COUNT: number = 15

--- a/src/lib/wasm/MultipassStore.ts
+++ b/src/lib/wasm/MultipassStore.ts
@@ -12,6 +12,7 @@ import { parseJSValue } from "./EnumParser"
 import { ToastMessage } from "$lib/state/ui/toast"
 import { SettingsStore } from "$lib/state"
 import { Sounds } from "$lib/components/utils/SoundHandler"
+import { MAX_RETRY_COUNT, RETRY_DELAY } from "$lib/config"
 
 /**
  * A class that provides various methods to interact with a MultiPassBox.
@@ -63,10 +64,10 @@ class MultipassStore {
                         while (incoming === undefined) {
                             incoming = await this.identity_from_did(event.did)
                             count++
-                            if (count > 15) {
+                            if (count > MAX_RETRY_COUNT) {
                                 break;
                             }
-                            await new Promise(resolve => setTimeout(resolve, 1000));
+                            await new Promise(resolve => setTimeout(resolve, RETRY_DELAY));
                         }
                         if (incoming) {
                             Store.addToastNotification(new ToastMessage("New friend request.", `${incoming?.name} sent a request.`, 2), Sounds.Notification)
@@ -558,7 +559,7 @@ class MultipassStore {
                     [wasm.IdentityStatus.Away]: Status.Idle,
                     [wasm.IdentityStatus.Busy]: Status.DoNotDisturb,
                     [wasm.IdentityStatus.Offline]: Status.Offline,
-                  }
+                }
                 status = identityStatusMap[identityStatus] ?? Status.Offline
             } catch (error) {
                 log.error(`Couldn't fetch status for ${did}: ${error}`)
@@ -573,7 +574,7 @@ class MultipassStore {
         if (multipass) {
             try {
                 let identityProfilePicture = await multipass.identity_picture(did)
-                profilePicture = identityProfilePicture ? this.to_base64(identityProfilePicture.data()) : ""    
+                profilePicture = identityProfilePicture ? this.to_base64(identityProfilePicture.data()) : ""
             } catch (error) {
                 // log.error(`Couldn't fetch profile picture for ${did}: ${error}`)
             }
@@ -587,7 +588,7 @@ class MultipassStore {
         if (multipass) {
             try {
                 let identityBannerPicture = await multipass.identity_banner(did)
-                bannerPicture = identityBannerPicture ? this.to_base64(identityBannerPicture.data()) : ""    
+                bannerPicture = identityBannerPicture ? this.to_base64(identityBannerPicture.data()) : ""
             } catch (error) {
                 // log.error(`Couldn't fetch banner picture for ${did}: ${error}`)
             }
@@ -602,7 +603,7 @@ class MultipassStore {
         const base64String = btoa(binaryString)
         const cleanedBase64String = base64String.replace('dataimage/jpegbase64', '')
         return `data:image/jpeg;base64,${cleanedBase64String}`
-      }
+    }
 
     /**
      * Updates the identity state.


### PR DESCRIPTION
…friend request

<!--  Thanks for sending a pull request!-->

### What this PR does 📖
#### 1. Guarantee name not come as undefiend on toast message when receive a friend request

### Which issue(s) this PR fixes 🔨

- Resolve #242 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
