### PR TITLE
fix(Conversations): Fix conversations breaking after refresh

### DIFF
--- a/src/lib/wasm/RaygunStore.ts
+++ b/src/lib/wasm/RaygunStore.ts
@@ -24,33 +24,33 @@ const MAX_PINNED_MESSAGES = 100
 // Ok("{\"AttachedProgress\":[{\"Constellation\":{\"path\":\"path\"}},{\"CurrentProgress\":{\"name\":\"name\",\"current\":5,\"total\":null}}]}")
 export type FetchMessagesConfig =
     | {
-          type: "MostRecent"
-          amount: number
-      }
+        type: "MostRecent"
+        amount: number
+    }
     // fetch messages which occur earlier in time
     | {
-          type: "Earlier"
-          start_date: Date
-          limit: number
-      }
+        type: "Earlier"
+        start_date: Date
+        limit: number
+    }
     // fetch messages which occur later in time
     | {
-          type: "Later"
-          start_date: Date
-          limit: number
-      }
+        type: "Later"
+        start_date: Date
+        limit: number
+    }
     // fetch messages between given time
     | {
-          type: "Between"
-          from: Date
-          to: Date
-      }
+        type: "Between"
+        from: Date
+        to: Date
+    }
     // fetch half_size messages before and after center.
     | {
-          type: "Window"
-          start_date: Date
-          half_size: number
-      }
+        type: "Window"
+        start_date: Date
+        half_size: number
+    }
 
 export type FetchMessageResponse = {
     messages: Message[]
@@ -70,14 +70,14 @@ export type MultiSendMessageResult = {
 
 export type ConversationSettings =
     | {
-          direct: {}
-      }
+        direct: {}
+    }
     | {
-          group: {
-              members_can_add_participants: boolean
-              members_can_change_name: boolean
-          }
-      }
+        group: {
+            members_can_add_participants: boolean
+            members_can_change_name: boolean
+        }
+    }
 
 export type FileAttachment = {
     file: string
@@ -99,7 +99,6 @@ class RaygunStore {
         this.messageListeners = writable({})
         this.raygunWritable.subscribe(r => {
             if (r) {
-                this.handleRaygunEvent(r)
                 let listeners = get(this.messageListeners)
                 if (Object.keys(listeners).length > 0) {
                     // Cancels current message event listeners
@@ -108,6 +107,9 @@ class RaygunStore {
                     }
                 }
                 this.initConversationHandlers(r)
+                // handleRaygunEvent must be called after initConversationHandlers
+                // this is because if 'raygun.raygun_subscribe' is called before 'raygun.list_conversations', it causes 'raygun.list_conversations' to hang. (reason currently unknown)
+                this.handleRaygunEvent(r)
             }
         })
     }
@@ -406,8 +408,9 @@ class RaygunStore {
         let conversations: { inner: wasm.Conversation }[] = await raygun.list_conversations()
         let handlers: { [key: string]: Cancellable } = {}
         for (let conversation of conversations) {
-            let handler = await this.createConversationEventHandler(raygun, conversation.inner.id())
-            handlers[conversation.inner.id()] = handler
+            //typescript thinks id is a function, but in the browser it is not.
+            let handler = await this.createConversationEventHandler(raygun, conversation.inner.id)
+            handlers[conversation.inner.id] = handler
         }
         this.messageListeners.set(handlers)
     }
@@ -574,7 +577,7 @@ class RaygunStore {
             for await (const value of listener) {
                 data = [...data, ...value]
             }
-        } catch (_) {}
+        } catch (_) { }
         let blob = new Blob([new Uint8Array(data)])
         const elem = window.document.createElement("a")
         elem.href = window.URL.createObjectURL(blob)


### PR DESCRIPTION
### What this PR does 📖

- Fixes conversations breaking after refresh. 
1) `raygun.raygun_subscribe()` being called before `raygun.list_conversations()` was causing it to hang. This shouldn't happen and we don't know why it happens, and I could not reproduce it on in simple js script. However, reversing the order they are called allows uplinkweb to work properly. I've left a comment in the code about it, until we can figure out the root cause.
2) `conversation.inner.id()` is a function in rust that returns a string. when it gets compiled to wasm it is still a function, as can be seen in the generated typescript. But somehow the browser only recognizes it as a field and otherwise throws an error that the function doesn't exist. changing it to use it as a field allows it to work in the browser, although in your IDE, typescript will complain that you can't assign a function to a string. I left a comment in the code to this effect.

### Which issue(s) this PR fixes 🔨

### Special notes for reviewers 🗒️

### Additional comments 🎤
