### PR TITLE
feat(chat): Conversation rework

### DIFF
--- a/src/lib/components/Polling.svelte
+++ b/src/lib/components/Polling.svelte
@@ -76,7 +76,7 @@
 
                     if (activeChat.id === chat.id) {
                         Store.state.activeChat.set(chat)
-                        let conversation = ConversationStore.getConversation(activeChat)
+                        let conversation = get(ConversationStore.getConversation(activeChat))
                         conversation?.messages.forEach(message => {
                             message.messages.forEach(m => {
                                 m.details.origin = chat.users.find(u => u.key === m.details.origin.key) ?? m.details.origin

--- a/src/lib/state/Store.ts
+++ b/src/lib/state/Store.ts
@@ -389,14 +389,7 @@ class GlobalStore {
         this.state.friends.set(mock_users.map(u => u.key))
         this.state.blocked.set(blocked_users.map(u => u.key))
         this.state.favorites.set([activeChat])
-        ConversationStore.conversations.set(
-            mchatsMod.map(c => {
-                return {
-                    id: c.id,
-                    messages: [],
-                }
-            })
-        )
+        ConversationStore.addConversations(mchatsMod.map(c => c.id))
     }
 }
 

--- a/src/lib/state/conversation/index.ts
+++ b/src/lib/state/conversation/index.ts
@@ -6,6 +6,9 @@ import { mock_messages } from "$lib/mock/messages"
 import { Appearance } from "$lib/enums"
 import { Store } from "../Store"
 import { UIStore } from "../ui"
+import { bool } from "three/examples/jsm/nodes/Nodes.js"
+
+type ConversationMessagesMap = { [id: string]: Writable<ConversationMessages> }
 
 export type ConversationMessages = {
     id: string
@@ -13,48 +16,105 @@ export type ConversationMessages = {
 }
 
 class Conversations {
-    conversations: Writable<ConversationMessages[]>
+    /**
+     * INTERNAL!
+     * This is synced with #conversationsN and purely for saving to DB as DB cannot directly save Writable
+     */
+    private conversationsDB: ConversationMessages[]
+    private conversations: Writable<ConversationMessagesMap>
     // We use a new writable so they dont get saved to db
     pendingMsgConversations: Writable<{ [conversation: string]: { [id: string]: PendingMessage } }>
 
     constructor() {
-        this.conversations = writable([])
+        this.conversationsDB = []
+        this.conversations = writable({})
         this.pendingMsgConversations = writable({})
         this.loadConversations()
+        this.conversations.subscribe(async convsStore => {
+            // Update the whole conversationsDB whenever the main store changes
+            // as that indicates an addition/removal of conversations
+            this.conversationsDB = Object.values(convsStore).map(msgStore => {
+                return get(msgStore)
+            })
+            await setStateToDB("conversations", this.conversationsDB)
+        })
     }
 
     async loadConversations() {
         // TODO: Instead of storing all conversations under one entry, we should store each conversation in it's own table row.
         const dbConversations = await getStateFromDB<ConversationMessages[]>("conversations", [])
-        this.conversations.set(dbConversations)
+        this.conversationsDB = dbConversations
+        let convN = this.conversationsDB.reduce((map, conv) => {
+            map[conv.id] = this.createConversation(conv)
+            return map
+        }, {} as ConversationMessagesMap)
+        this.conversations.set(convN)
+    }
+
+    private createConversation(conv: ConversationMessages) {
+        let wr = writable(conv)
+        let init = true
+        wr.subscribe(async conv => {
+            if (init) {
+                init = false
+                return
+            }
+            const conversationIndex = this.conversationsDB.findIndex(c => c.id === conv.id)
+            if (conversationIndex !== -1) {
+                this.conversationsDB[conversationIndex] = conv
+                await setStateToDB("conversations", this.conversationsDB)
+            }
+        })
+        return wr
     }
 
     getConversation(chat: Chat | string) {
         let chatId = typeof chat === "string" ? chat : chat.id
-        return get(this.conversations).find(c => c.id === chatId)
+        return get(this.conversations)[chatId]
+    }
+
+    addConversations(chats: string[]) {
+        this.conversations.update(convs => {
+            for (let chat of chats) {
+                convs[chat] = this.createConversation({
+                    id: chat,
+                    messages: [],
+                })
+            }
+            return convs
+        })
+    }
+
+    removeConversation(chat: string) {
+        this.conversations.update(convs => {
+            delete convs[chat]
+            return convs
+        })
     }
 
     async addMessage(chat: Chat | string, message: Message) {
         let chatId = typeof chat === "string" ? chat : chat.id
         const conversations = get(this.conversations)
-        const conversationIndex = conversations.findIndex(c => c.id === chatId)
+        const conversation = conversations[chatId]
 
         if (message.id === "") message.id = uuidv4()
 
-        if (conversationIndex !== -1) {
-            const conversation = conversations[conversationIndex]
-            const lastGroup = conversation.messages[conversation.messages.length - 1]
-            const now = new Date()
+        if (conversation) {
+            conversation.update(conv => {
+                const lastGroup = conv.messages[conv.messages.length - 1]
+                const now = new Date()
 
-            if (lastGroup && lastGroup.details.origin === message.details.origin && now.getTime() - new Date(lastGroup.details.at).getTime() < 60000) {
-                lastGroup.messages.push(message)
-            } else {
-                const newMessageGroup: MessageGroup = {
-                    details: message.details,
-                    messages: [message],
+                if (lastGroup && lastGroup.details.origin === message.details.origin && now.getTime() - new Date(lastGroup.details.at).getTime() < 60000) {
+                    lastGroup.messages.push(message)
+                } else {
+                    const newMessageGroup: MessageGroup = {
+                        details: message.details,
+                        messages: [message],
+                    }
+                    conv.messages.push(newMessageGroup)
                 }
-                conversation.messages.push(newMessageGroup)
-            }
+                return conv
+            })
         } else {
             const newConversation: ConversationMessages = {
                 id: chatId,
@@ -65,42 +125,42 @@ class Conversations {
                     },
                 ],
             }
-            conversations.push(newConversation)
+            conversations[chatId] = this.createConversation(newConversation)
+            this.conversations.set(conversations)
         }
-        this.conversations.set(conversations)
         UIStore.mutateChat(chatId, c => {
             c.last_message_preview = message.text.join("\n")
         })
-        await setStateToDB("conversations", conversations)
     }
 
     async editMessage(chat: Chat | string, messageId: string, editedContent: string) {
         let chatId = typeof chat === "string" ? chat : chat.id
         const conversations = get(this.conversations)
-        const conversation = conversations.find(c => c.id === chatId)
+        const conversation = conversations[chatId]
         if (conversation) {
-            conversation.messages.forEach(group => {
-                const messageIndex = group.messages.findIndex(m => m.id === messageId)
-                if (messageIndex !== -1) {
-                    group.messages[messageIndex] = {
-                        ...group.messages[messageIndex],
-                        text: [editedContent],
+            conversation.update(conv => {
+                conv.messages.forEach(group => {
+                    const messageIndex = group.messages.findIndex(m => m.id === messageId)
+                    if (messageIndex !== -1) {
+                        group.messages[messageIndex] = {
+                            ...group.messages[messageIndex],
+                            text: [editedContent],
+                        }
                     }
-                }
+                })
+                return conv
             })
-
-            this.conversations.set(conversations)
-            await setStateToDB("conversations", conversations)
         }
     }
 
     hasReaction(chat: Chat | string, messageId: string, emoji: string) {
         let chatId = typeof chat === "string" ? chat : chat.id
         const conversations = get(this.conversations)
-        const conversation = conversations.find(c => c.id === chatId)
+        const conversationStore = conversations[chatId]
         const user = get(Store.state.user).key
 
-        if (conversation) {
+        if (conversationStore) {
+            const conversation = get(conversationStore)
             for (let group of conversation.messages) {
                 const messageIndex = group.messages.findIndex(m => m.id === messageId)
                 if (messageIndex !== -1) {
@@ -115,97 +175,98 @@ class Conversations {
 
     async editReaction(chat: string, messageId: string, emoji: string, add: boolean, reactor?: string) {
         const conversations = get(this.conversations)
-        const conversation = conversations.find(c => c.id === chat)
+        const conversation = conversations[chat]
         const user = reactor ? reactor : get(Store.state.user).key
 
         if (conversation) {
-            conversation.messages.forEach(group => {
-                const messageIndex = group.messages.findIndex(m => m.id === messageId)
-                if (messageIndex !== -1) {
-                    const reactions = group.messages[messageIndex].reactions
-                    const reaction = reactions[emoji]
-                    if (!add) {
-                        if (reaction !== undefined) {
-                            let reactors = reaction.reactors
-                            reactors.delete(user)
-                            if (reactors && reactors.size === 0) {
-                                delete reactions[emoji]
-                            } else {
+            conversation.update(conv => {
+                conv.messages.forEach(group => {
+                    const messageIndex = group.messages.findIndex(m => m.id === messageId)
+                    if (messageIndex !== -1) {
+                        const reactions = group.messages[messageIndex].reactions
+                        const reaction = reactions[emoji]
+                        if (!add) {
+                            if (reaction !== undefined) {
+                                let reactors = reaction.reactors
+                                reactors.delete(user)
+                                if (reactors && reactors.size === 0) {
+                                    delete reactions[emoji]
+                                } else {
+                                    reactions[emoji] = {
+                                        ...reaction,
+                                        reactors,
+                                    }
+                                }
+                            }
+                        } else {
+                            if (reaction !== undefined) {
                                 reactions[emoji] = {
                                     ...reaction,
-                                    reactors,
+                                    reactors: reaction.reactors.add(user),
+                                }
+                            } else {
+                                reactions[emoji] = {
+                                    reactors: new Set([user]),
+                                    emoji: emoji,
+                                    highlight: Appearance.Default, //TODO
+                                    description: "", //TODO
                                 }
                             }
                         }
-                    } else {
-                        if (reaction !== undefined) {
-                            reactions[emoji] = {
-                                ...reaction,
-                                reactors: reaction.reactors.add(user),
-                            }
-                        } else {
-                            reactions[emoji] = {
-                                reactors: new Set([user]),
-                                emoji: emoji,
-                                highlight: Appearance.Default, //TODO
-                                description: "", //TODO
-                            }
+                        group.messages[messageIndex] = {
+                            ...group.messages[messageIndex],
+                            reactions: reactions,
                         }
                     }
-                    group.messages[messageIndex] = {
-                        ...group.messages[messageIndex],
-                        reactions: reactions,
-                    }
-                }
+                })
+                return conv
             })
-
-            this.conversations.set(conversations)
-            await setStateToDB("conversations", conversations)
         }
     }
 
     async removeMessage(chat: string, messageId: string) {
         const conversations = get(this.conversations)
-        const conversation = conversations.find(c => c.id === chat)
+        const conversation = conversations[chat]
 
         if (conversation) {
-            conversation.messages.forEach(group => {
-                const index = group.messages.findIndex(m => m.id === messageId)
-                if (index !== -1) {
-                    group.messages.splice(index, 1)
-                }
+            conversation.update(conv => {
+                conv.messages.forEach(group => {
+                    const index = group.messages.findIndex(m => m.id === messageId)
+                    if (index !== -1) {
+                        group.messages.splice(index, 1)
+                    }
+                })
+                conv.messages = conv.messages.filter(group => group.messages.length > 0)
+                return conv
             })
-            conversation.messages = conversation.messages.filter(group => group.messages.length > 0)
-            this.conversations.set(conversations)
-            await setStateToDB("conversations", conversations)
         }
     }
 
     async pinMessage(chat: Chat | string, messageId: string, pin: boolean) {
         let chatId = typeof chat === "string" ? chat : chat.id
         const conversations = get(this.conversations)
-        const conversation = conversations.find(c => c.id === chatId)
+        const conversation = conversations[chatId]
         if (conversation) {
-            conversation.messages.forEach(group => {
-                const messageIndex = group.messages.findIndex(m => m.id === messageId)
-                if (messageIndex !== -1) {
-                    group.messages[messageIndex] = {
-                        ...group.messages[messageIndex],
-                        pinned: pin,
+            conversation.update(conv => {
+                conv.messages.forEach(group => {
+                    const messageIndex = group.messages.findIndex(m => m.id === messageId)
+                    if (messageIndex !== -1) {
+                        group.messages[messageIndex] = {
+                            ...group.messages[messageIndex],
+                            pinned: pin,
+                        }
                     }
-                }
+                })
+                return conv
             })
-
-            this.conversations.set(conversations)
-            await setStateToDB("conversations", conversations)
         }
     }
 
     getMessage(chat: string, messageId: string): Message | null {
         const conversations = get(this.conversations)
-        const conversation = conversations.find(c => c.id === chat)
+        const conversation = conversations[chat]
         if (conversation) {
-            conversation.messages.forEach(group => {
+            get(conversation).messages.forEach(group => {
                 const messageIndex = group.messages.findIndex(m => m.id === messageId)
                 if (messageIndex !== -1) {
                     return group.messages[messageIndex]
@@ -276,18 +337,13 @@ class Conversations {
     }
 
     async loadMockData() {
-        const firstChatId = get(this.conversations)[0].id
-        const initialData: ConversationMessages = {
+        const firstChatId = this.conversationsDB[0].id
+        const initialData: Writable<ConversationMessages> = this.createConversation({
             id: firstChatId,
             messages: mock_messages,
-        }
+        })
         this.conversations.update(currentConversations => {
-            const index = currentConversations.findIndex(c => c.id === firstChatId)
-            if (index !== -1) {
-                currentConversations[index] = initialData
-            } else {
-                currentConversations.push(initialData)
-            }
+            currentConversations[firstChatId] = initialData
             return currentConversations
         })
         // this.pendingMsgConversations.set({
@@ -320,7 +376,6 @@ class Conversations {
         //         },
         //     },
         // })
-        await setStateToDB("conversations", get(this.conversations))
     }
 }
 

--- a/src/lib/state/conversation/index.ts
+++ b/src/lib/state/conversation/index.ts
@@ -7,6 +7,7 @@ import { Appearance } from "$lib/enums"
 import { Store } from "../Store"
 import { UIStore } from "../ui"
 import { bool } from "three/examples/jsm/nodes/Nodes.js"
+import { mchats } from "$lib/mock/users"
 
 type ConversationMessagesMap = { [id: string]: Writable<ConversationMessages> }
 
@@ -337,7 +338,7 @@ class Conversations {
     }
 
     async loadMockData() {
-        const firstChatId = this.conversationsDB[0].id
+        const firstChatId = mchats[0].id
         const initialData: Writable<ConversationMessages> = this.createConversation({
             id: firstChatId,
             messages: mock_messages,

--- a/src/lib/wasm/RaygunStore.ts
+++ b/src/lib/wasm/RaygunStore.ts
@@ -399,8 +399,7 @@ class RaygunStore {
 
                     // Update stores
                     UIStore.removeSidebarChat(conversationId)
-                    let conversations = get(ConversationStore.conversations)
-                    ConversationStore.conversations.set(conversations.filter(c => c.id !== conversationId))
+                    ConversationStore.removeConversation(conversationId)
                     if (get(Store.state.activeChat).id === conversationId) {
                         Store.clearActiveChat()
                     }

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -60,7 +60,7 @@
     $: isFavorite = derived(Store.state.favorites, favs => favs.some(f => f.id === $activeChat.id))
     $: conversation = ConversationStore.getConversation($activeChat)
     $: users = Store.getUsersLookup($activeChat.users)
-    $: chatName = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.name : ($activeChat.name ?? $users[$activeChat.users[1]]?.name)
+    $: chatName = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.name : $activeChat.name ?? $users[$activeChat.users[1]]?.name
     $: statusMessage = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.profile?.status_message : $activeChat.motd
 
     const timeAgo = new TimeAgo("en-US")
@@ -182,20 +182,20 @@
     async function edit_message(message: string, text: string) {
         editing_message = undefined
         editing_text = undefined
-        await RaygunStoreInstance.edit(conversation!.id, message, text.split("\n"))
+        await RaygunStoreInstance.edit($conversation!.id, message, text.split("\n"))
     }
 
     async function delete_message(message: string) {
-        await RaygunStoreInstance.delete(conversation!.id, message)
+        await RaygunStoreInstance.delete($conversation!.id, message)
     }
 
     async function reactTo(message: string, emoji: string, toggle: boolean) {
         let add = toggle ? !ConversationStore.hasReaction($activeChat, message, emoji) : true
-        await RaygunStoreInstance.react(conversation!.id, message, add ? 0 : 1, emoji)
+        await RaygunStoreInstance.react($conversation!.id, message, add ? 0 : 1, emoji)
     }
 
     async function pin_message(message: string) {
-        await RaygunStoreInstance.pin(conversation!.id, message, true)
+        await RaygunStoreInstance.pin($conversation!.id, message, true)
     }
 
     async function copy(txt: string) {
@@ -203,7 +203,7 @@
     }
 
     async function download_attachment(message: string, attachment: Attachment) {
-        await RaygunStoreInstance.downloadAttachment(conversation!.id, message, attachment.name, attachment.size)
+        await RaygunStoreInstance.downloadAttachment($conversation!.id, message, attachment.name, attachment.size)
     }
 </script>
 
@@ -424,7 +424,7 @@
             {#if $activeChat.users.length > 0}
                 <EncryptedNotice />
                 {#if conversation}
-                    {#each conversation.messages as group}
+                    {#each $conversation.messages as group}
                         <StoreResolver value={group.details.origin} resolver={v => Store.getUser(v)} let:resolved>
                             <MessageGroup
                                 profilePictureRequirements={{


### PR DESCRIPTION
### What this PR does 📖

- Redo conversation store
  - Makes looking up conversation by id better by using a keyed object instead of array
  - Every chat conversation is now a writable and attempting to fetch the conversation for a chat returns this writable. This makes it possible for svelte to update components on change
  - Remove manual syncing with database on each change. Now its done automatically

### Which issue(s) this PR fixes 🔨

- Resolve #318