### PR TITLE
chore(pin): add enter on pin

### DIFF
--- a/src/lib/components/PinInput.svelte
+++ b/src/lib/components/PinInput.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher, onMount } from "svelte"
     import { Appearance, Shape } from "$lib/enums"
-
     import { Button, Icon, Spacer, Loader, Switch, Label } from "$lib/elements"
-
     import { _ } from "svelte-i18n"
     import { AuthStore } from "$lib/state/auth"
 
@@ -60,17 +58,21 @@
     function onSubmit(pin: string) {
         dispatch("submit", pin)
     }
+
     // Placeholder for submit action
     const submitPinValue = () => {
         onSubmit(pinValue)
         clearPinValue()
     }
 
-    function handleKeyDown(event: { key: any }) {
+    function handleKeyDown(event: KeyboardEvent) {
         const key = event.key
         // Check if the key is a digit
-        if (!isNaN(key) && key !== " ") {
+        if (!isNaN(Number(key)) && key !== " ") {
             updatePinValue(key)
+        } else if (key === 'Enter') {
+            event.preventDefault()
+            submitPinValue()
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- On sign up, when you are on the pin page, after you add the pin you can use enter and it has the same behavior as the confirm pin green button

