### PR TITLE
fix(settings): Fix banner/profile reset on changes

### DIFF
--- a/src/lib/state/Store.ts
+++ b/src/lib/state/Store.ts
@@ -41,7 +41,7 @@ class GlobalStore {
         }
     }
 
-    setUserFromIdentity(identity: wasm.Identity) {
+    setUserFromIdentity(identity: wasm.Identity, photo?: string, banner?: string) {
         let userFromIdentity: User = {
             ...defaultUser,
             id: { short: identity.short_id() },
@@ -49,6 +49,8 @@ class GlobalStore {
             key: identity.did_key(),
             profile: {
                 ...defaultUser.profile,
+                photo: { ...defaultUser.profile.photo, image: photo ? photo : "" },
+                banner: { ...defaultUser.profile.banner, image: banner ? banner : "" },
                 status: Status.Online,
                 status_message: identity.status_message() || "",
             },

--- a/src/lib/wasm/MultipassStore.ts
+++ b/src/lib/wasm/MultipassStore.ts
@@ -652,8 +652,10 @@ class MultipassStore {
         if (multipass) {
             try {
                 const updated_identity = await multipass.identity()
+                let profilePicture = await this.getUserProfilePicture(updated_identity.did_key())
+                let bannerPicture = await this.getUserBannerPicture(updated_identity.did_key())
                 this.identity.update(() => updated_identity)
-                Store.setUserFromIdentity(updated_identity)
+                Store.setUserFromIdentity(updated_identity, profilePicture, bannerPicture)
                 log.info(`Identity updated\n 
                   Username: ${updated_identity.username()} \n
                   StatusMessage: ${updated_identity.status_message()} \n`)

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -74,8 +74,7 @@
             },
             async (identity: Identity) => {
                 AuthStore.logIn(true)
-                Store.setUserFromIdentity(identity!)
-                Store.setPhoto(profilePicture)
+                Store.setUserFromIdentity(identity!, profilePicture)
                 await new Promise(resolve => setTimeout(resolve, 1000))
                 setTimeout(() => MultipassStoreInstance.initMultipassListener(), 1000)
                 goto(Route.Chat)

--- a/src/routes/settings/profile/+page.svelte
+++ b/src/routes/settings/profile/+page.svelte
@@ -81,21 +81,22 @@
     let userReference: User = { ...get(Store.state.user) }
     let statusMessage: string = { ...get(Store.state.user) }.profile.status_message
 
-    onDestroy(() => {
-        Store.setUsername(userReference.name)
-        Store.setStatusMessage(userReference.profile.status_message)
-    })
-
     $: user = Store.state.user
     let key: string = ""
     let activityStatus: Status = Status.Offline
 
-    Store.state.user.subscribe(val => {
+    const userSub = Store.state.user.subscribe(val => {
         let user = val
         userReference = { ...val }
         statusMessage = user.profile.status_message
         activityStatus = user.profile.status
         key = user.key
+    })
+
+    onDestroy(() => {
+        Store.setUsername(userReference.name)
+        Store.setStatusMessage(userReference.profile.status_message)
+        userSub()
     })
 
     let acceptableFiles: string = ".jpg, .jpeg, .png, .avif, .webp"


### PR DESCRIPTION
### What this PR does 📖

- Fixes user profile picture and banner being reset when something changes in settings. (e.g. by editing the status message)

### Which issue(s) this PR fixes 🔨

- Resolve #332
