### PR TITLE
update(fix): fix chat preview context menu text for hide chat

### DIFF
--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -61,6 +61,8 @@
     $: isFavorite = derived(Store.state.favorites, favs => favs.some(f => f.id === $activeChat.id))
     $: conversation = ConversationStore.getConversation($activeChat)
     $: users = Store.getUsersLookup($activeChat.users)
+    $: loading = $users[$activeChat.users[1]]?.name === undefined
+
     $: chatName = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.name : ($activeChat.name ?? $users[$activeChat.users[1]]?.name)
     $: statusMessage = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.profile?.status_message : $activeChat.motd
     $: pinned = getPinned($conversation)

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -60,7 +60,7 @@
     $: isFavorite = derived(Store.state.favorites, favs => favs.some(f => f.id === $activeChat.id))
     $: conversation = ConversationStore.getConversation($activeChat)
     $: users = Store.getUsersLookup($activeChat.users)
-    $: chatName = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.name : $activeChat.name ?? $users[$activeChat.users[1]]?.name
+    $: chatName = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.name : ($activeChat.name ?? $users[$activeChat.users[1]]?.name)
     $: statusMessage = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.profile?.status_message : $activeChat.motd
     $: pinned = getPinned($conversation)
     const timeAgo = new TimeAgo("en-US")
@@ -368,7 +368,7 @@
                     {
                         id: "hide",
                         icon: Shape.EyeSlash,
-                        text: $_("chat.gide"),
+                        text: $_("chat.hide"),
                         appearance: Appearance.Default,
                         onClick: () => UIStore.removeSidebarChat(chat),
                     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Fixes an error with preview chat context menu showing chat.gide instead of "Hide" (just a typo in code)

currently in dev:
![image](https://github.com/user-attachments/assets/3d516a79-58c0-4f33-a0fd-817117e12a79)


with this pr:
![image](https://github.com/user-attachments/assets/b4fdee18-112c-4290-8f91-859899fadbe5)


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
