### PR TITLE
fix(Styling): Fix weird styling for generic integration kinds

### DIFF
--- a/src/lib/components/inventory/InventoryItem.svelte
+++ b/src/lib/components/inventory/InventoryItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { Text, Icon, Button } from "$lib/elements"
+    import Loader from "$lib/elements/Loader.svelte"
     import { Appearance, InventoryKind, Shape } from "$lib/enums"
     import { createEventDispatcher } from "svelte"
     import { _ } from "svelte-i18n"
@@ -14,13 +15,21 @@
     export let hook: string = ""
 
     const dispatch = createEventDispatcher()
+    let loaded = false
+
+    function handleImageLoad() {
+        loaded = true
+    }
 </script>
 
 <div data-cy={hook} class="inventory-item {equipped ? 'equipped' : ''}">
     {#if empty}
         <img src="/assets/frames/empty.png" alt="" class="preview" />
     {:else}
-        <img src={preview} alt="" class="preview" />
+        {#if !loaded}
+            <Loader />
+        {/if}
+        <img src={preview} alt="" class="preview" on:load={handleImageLoad} style:display={loaded ? "block" : "none"} />
     {/if}
     <Text hook="inventory-item-name">{name}</Text>
     <Text hook="inventory-item-type" muted>{kind}</Text>
@@ -69,6 +78,16 @@
 
         .preview {
             max-width: 180px;
+        }
+
+        .loading-indicator {
+            width: 180px;
+            height: 180px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background-color: var(--loading-background-color);
+            color: var(--loading-text-color);
         }
     }
 </style>

--- a/src/lib/lang/en.json
+++ b/src/lib/lang/en.json
@@ -32,7 +32,8 @@
         "faves": "Faves",
         "initializing": "Initializing...",
         "platform": "Platform",
-        "address": "Address"
+        "address": "Address",
+        "label": "Label"
     },
     "market": {
         "market": "Marketplace",

--- a/src/routes/settings/profile/+page.svelte
+++ b/src/routes/settings/profile/+page.svelte
@@ -416,11 +416,14 @@
                                         }
                                     }} />
                             {/if}
-                            {#if selectedKind === Integrations.Generic}
-                                <Input hook="input-account-integrations-new-generic" alt bind:value={selectedKey} disabled={$user.integrations.has(selectedKey)} />
-                            {/if}
                         </div>
                         <img class="integration-logo" data-cy="logo-account-integrations-new" src={toIntegrationIconSrc(selectedKey)} alt="Platform Logo" />
+                        {#if selectedKind === Integrations.Generic}
+                            <div class="label">
+                                <Label hook="label-account-integration-new-address" text={$_("generic.label")} />
+                                <Input hook="input-account-integrations-new-generic" alt bind:value={selectedKey} disabled={$user.integrations.has(selectedKey)} />
+                            </div>
+                        {/if}
                         <div class="right">
                             <Label hook="label-account-integration-new-address" text={$_("generic.address")} />
                             <Input hook="input-account-integrations-new-address" alt bind:value={selectedKeyEditValue} />


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
Previously when selecting a generic integration type, it would have an input below the select box, this change inlines that input and labels it as well so things look a bit cleaner.

Before:
<img width="2088" alt="image" src="https://github.com/user-attachments/assets/8f22ee8a-9359-4814-88df-b895809ea077">

After:
<img width="2059" alt="image" src="https://github.com/user-attachments/assets/938d76be-3e68-4ad3-8163-cf9ad16acb81">

