### PR TITLE
fix(tooltip): adjust padding and gaps to allow scroll

### DIFF
--- a/src/lib/components/CoinBalance.svelte
+++ b/src/lib/components/CoinBalance.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <Button outline appearance={Appearance.Alt}>
-    <Icon icon={Shape.Starlight} size={Size.Large} highlight={Appearance.Warning} />
+    <Icon icon={Shape.Starlight} size={Size.Medium} highlight={Appearance.Warning} />
     <!-- svelte-ignore a11y-label-has-associated-control -->
     <Text size={Size.Small} secondaryFont>
         {NumberFormatter(balance, 2)}

--- a/src/lib/elements/Button.svelte
+++ b/src/lib/elements/Button.svelte
@@ -135,7 +135,7 @@
             &:before {
                 content: attr(data-tooltip);
                 position: absolute;
-                bottom: calc(100% + var(--gap));
+                bottom: calc(90% + var(--gap));
                 white-space: nowrap;
                 width: fit-content;
                 padding: var(--padding-minimal) var(--padding-less);
@@ -146,7 +146,7 @@
                 text-align: center;
                 opacity: 0;
                 pointer-events: none;
-                z-index: 2;
+                z-index: 3;
                 transition: all var(--animation-speed);
                 background-color: var(--opaque-color);
                 backdrop-filter: blur(var(--blur-radius));

--- a/src/routes/friends/+page.svelte
+++ b/src/routes/friends/+page.svelte
@@ -323,7 +323,8 @@
                         {/if}
                     </div>
                 {/if}
-                <div class="section column">
+                <!-- <div class="friends-section"> -->
+                <div class="friends-section section column">
                     {#each Object.keys(groupUsersAlphabetically($friends)).sort() as letter}
                         {#if groupUsersAlphabetically($friends)[letter].length > 0}
                             <Label hook="label-friend-list-{letter}" text={letter} />
@@ -360,6 +361,7 @@
                         {/if}
                     {/each}
                 </div>
+                <!-- </div> -->
             {:else if tab === "active"}
                 <div class="section column" data-cy="friends-section-requests">
                     <Label hook="label-outgoing-requests" text={$_("friends.outgoing_requests")} />
@@ -448,16 +450,20 @@
                     padding: var(--padding);
                     border-radius: var(--border-radius);
                 }
+                .friends-section {
+                    padding-top: 15px;
+                    overflow-y: scroll;
+                }
+
                 .section {
                     display: inline-flex;
                     gap: var(--gap);
                     padding-bottom: var(--gap);
+                    // padding-top: var(--gap);
 
                     &.column {
                         flex-direction: column;
-                        min-height: var(--min-scroll-height);
-                        overflow-y: scroll;
-                        overflow-x: hidden;
+                        min-height: var(--min-scroll-height) + var(--gap);
                         padding-right: var(--padding);
                     }
                 }

--- a/src/routes/friends/+page.svelte
+++ b/src/routes/friends/+page.svelte
@@ -448,12 +448,15 @@
                     padding: var(--padding);
                     border-radius: var(--border-radius);
                 }
+                .friends-section {
+                    padding-top: 15px;
+                    overflow-y: scroll;
+                }
 
                 .section {
                     display: inline-flex;
                     gap: var(--gap);
                     padding-bottom: var(--gap);
-                    // padding-top: var(--gap);
 
                     &.column {
                         flex-direction: column;

--- a/src/routes/friends/+page.svelte
+++ b/src/routes/friends/+page.svelte
@@ -323,7 +323,6 @@
                         {/if}
                     </div>
                 {/if}
-                <!-- <div class="friends-section"> -->
                 <div class="friends-section section column">
                     {#each Object.keys(groupUsersAlphabetically($friends)).sort() as letter}
                         {#if groupUsersAlphabetically($friends)[letter].length > 0}
@@ -361,7 +360,6 @@
                         {/if}
                     {/each}
                 </div>
-                <!-- </div> -->
             {:else if tab === "active"}
                 <div class="section column" data-cy="friends-section-requests">
                     <Label hook="label-outgoing-requests" text={$_("friends.outgoing_requests")} />
@@ -449,10 +447,6 @@
                     border: var(--border-width) solid var(--border-color);
                     padding: var(--padding);
                     border-radius: var(--border-radius);
-                }
-                .friends-section {
-                    padding-top: 15px;
-                    overflow-y: scroll;
                 }
 
                 .section {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Moves scroll y to a higher parent div and gives a new gap amount to the tooltip to account for the clipping. Also, changed coinBallance button in chat to medium to allow centering with other buttons

### Which issue(s) this PR fixes 🔨

- Resolve #316 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

Couple examples...

![image](https://github.com/user-attachments/assets/9a0a7bd7-dcc8-4197-9f69-510dce1e95d2)

![image](https://github.com/user-attachments/assets/5237856b-f4d6-428a-9d13-e2194121ab64)


![image](https://github.com/user-attachments/assets/45082e80-46e0-449f-9f32-512f4822462f)


### Additional comments 🎤
