### PR TITLE
chore(ci): dont add failed label on publish report issues

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -139,15 +139,6 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Add label if any of build jobs failed
-              if: failure()
-              uses: buildsville/add-remove-label@v2.0.1
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  labels: |
-                      Failed Automated Test
-                  type: add
-
     remove-label:
         needs: [playwright-run, generate-report]
         runs-on: ubuntu-latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Sometimes the CI publish report job fails (we are still investigating the reason why) and the Failed Automated Tests label is added. Since the tests themselves are already passed, there is no need to add this label when publish report fails.

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
