### PR TITLE
fix(warnings): fix warnings on prod build

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -170,7 +170,7 @@ select {
 
 @font-face {
     font-family: "NotoEmoji";
-    src: url("/assets/emoji/NotoColorEmoji.ttf");
+    src: url("/assets/emoji/NotoEmoji.ttf");
 }
 
 @font-face {

--- a/src/lib/components/community/settings/roles/Role.svelte
+++ b/src/lib/components/community/settings/roles/Role.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { Role } from "$lib/types"
-
     export let role: Role
+    console.log(role)
 </script>
 
 <div class="role"></div>

--- a/src/lib/components/inventory/InventoryItem.svelte
+++ b/src/lib/components/inventory/InventoryItem.svelte
@@ -79,6 +79,9 @@
         .preview {
             max-width: 180px;
         }
+/* 
+
+  This selector is intentionally kept for future use
 
         .loading-indicator {
             width: 180px;
@@ -89,5 +92,7 @@
             background-color: var(--loading-background-color);
             color: var(--loading-text-color);
         }
+*/
+
     }
 </style>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Fix the following warnings when using `npm run build`

<img width="1231" alt="Captura de ecrã 2024-08-23, às 21 01 21" src="https://github.com/user-attachments/assets/7fbac295-be6b-4d3c-a910-297088bdc273">


How to test:
- `npm run build`
- the ones marked as red should not appear and the app should have the same behavior