### PR TITLE
fix(Call): Close settings and volume menu on call when click outside

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,7 @@
 {
-    "rust-analyzer.linkedProjects": [
-        "./yew/Cargo.toml",
-        "./yew/Cargo.toml"
-    ],
+    "rust-analyzer.linkedProjects": ["./yew/Cargo.toml", "./yew/Cargo.toml"],
     "html.format.indentInnerHtml": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "scm.showHistoryGraph": false
 }

--- a/src/lib/components/calling/CallScreen.svelte
+++ b/src/lib/components/calling/CallScreen.svelte
@@ -119,7 +119,23 @@
     let remoteVideoElement: HTMLVideoElement
     let localVideoCurrentSrc: HTMLVideoElement
 
+    function handleClickOutside(event: MouseEvent) {
+        const callSettingsElement = document.getElementById("call-settings")
+        const showVolumeElement = document.getElementById("volume-mixer")
+
+        if (callSettingsElement && !callSettingsElement.contains(event.target as Node)) {
+            showCallSettings = false
+            event.stopPropagation()
+        }
+
+        if (showVolumeElement && !showVolumeElement.contains(event.target as Node)) {
+            showVolumeMixer = false
+            event.stopPropagation()
+        }
+    }
+
     onMount(async () => {
+        document.addEventListener("mousedown", handleClickOutside)
         await checkPermissions()
         await VoiceRTCInstance.setVideoElements(remoteVideoElement, localVideoCurrentSrc)
 
@@ -148,6 +164,7 @@
     })
 
     onDestroy(() => {
+        document.removeEventListener("mousedown", handleClickOutside)
         subscribeOne()
         subscribeTwo()
         subscribeThree()
@@ -203,10 +220,12 @@
         <Controls>
             <div class="relative">
                 {#if showCallSettings}
-                    <CallSettings
-                        on:change={_ => {
-                            VoiceRTCInstance.updateLocalStream(true)
-                        }} />
+                    <div id="call-settings">
+                        <CallSettings
+                            on:change={_ => {
+                                VoiceRTCInstance.updateLocalStream(true)
+                            }} />
+                    </div>
                 {/if}
                 <Button
                     tooltip="Settings"
@@ -221,7 +240,9 @@
             </div>
             <div class="relative">
                 {#if showVolumeMixer}
-                    <VolumeMixer participants={chat.users} />
+                    <div id="volume-mixer">
+                        <VolumeMixer participants={chat.users} />
+                    </div>
                 {/if}
                 <Button
                     tooltip="Volume Mixer"


### PR DESCRIPTION
### What this PR does 📖
#### 1. Close settings and volume menu on call when click outside

### Which issue(s) this PR fixes 🔨

- Resolve #456 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
