### PR TITLE
add(tooltips): add missing tooltips on chat page

### DIFF
--- a/src/lib/elements/Button.svelte
+++ b/src/lib/elements/Button.svelte
@@ -29,6 +29,8 @@
                 return "tooltip-left"
             case TooltipPosition.RIGHT:
                 return "tooltip-right"
+            case TooltipPosition.BOTTOM:
+                return "tooltip-bottom"
             default:
                 return ""
         }

--- a/src/lib/enums/index.ts
+++ b/src/lib/enums/index.ts
@@ -156,6 +156,7 @@ export const enum TooltipPosition {
     LEFT,
     MIDDLE,
     RIGHT,
+    BOTTOM,
 }
 
 export const enum MessagePosition {

--- a/src/lib/lang/en.json
+++ b/src/lib/lang/en.json
@@ -76,7 +76,7 @@
         "chat": "Chat",
         "chat_plural": "Chats",
         "create": "Create Group Chat",
-        "add_attachment": "Add attachment",
+        "add_attachment": "Add Attachment",
         "emoji": "Emojis",
         "emojiPicker": "Emoji Picker",
         "gifSearch": "GIF Search",
@@ -111,7 +111,13 @@
                 "photo": "Change Photo",
                 "photo.description": "Allow anyone to change the group photo"
             }
-        }
+        },
+        "call": "Audio Call",
+        "videocall": "Video Call",
+        "pinned-messages": "Pinned",
+        "send-coin": "Send Coin",
+        "show-participants": "Participants",
+        "group-settings": "Settings"
     },
     "community": {
         "title": "Satellite Community - General",

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -66,7 +66,7 @@
     // TODO(Lucas): Need to improve that for chats when not necessary all users are friends
     $: loading = get(UIStore.state.chats).length > 0 && !$activeChat.users.slice(1).some(userId => $users[userId]?.name !== undefined)
 
-    $: chatName = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.name : $activeChat.name ?? $users[$activeChat.users[1]]?.name
+    $: chatName = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.name : ($activeChat.name ?? $users[$activeChat.users[1]]?.name)
     $: statusMessage = $activeChat.kind === ChatType.DirectMessage ? $users[$activeChat.users[1]]?.profile?.status_message : $activeChat.motd
     $: pinned = getPinned($conversation)
 
@@ -419,6 +419,8 @@
                 <svelte:fragment slot="controls">
                     <Button
                         hook="button-chat-call"
+                        tooltip={$_("chat.call")}
+                        tooltipPosition={TooltipPosition.BOTTOM}
                         loading={loading}
                         icon
                         appearance={Appearance.Alt}
@@ -433,6 +435,8 @@
                     <Button
                         icon
                         hook="button-chat-video"
+                        tooltip={$_("chat.videocall")}
+                        tooltipPosition={TooltipPosition.BOTTOM}
                         appearance={Appearance.Alt}
                         disabled={$activeChat.users.length === 0}
                         loading={loading}
@@ -446,6 +450,8 @@
                     <Button
                         icon
                         hook="button-chat-favorite"
+                        tooltip={$_("chat.favorite")}
+                        tooltipPosition={TooltipPosition.BOTTOM}
                         disabled={$activeChat.users.length === 0}
                         loading={loading}
                         appearance={$isFavorite ? Appearance.Primary : Appearance.Alt}
@@ -456,6 +462,8 @@
                     </Button>
                     <Button
                         hook="button-chat-pin"
+                        tooltip={$_("chat.pinned-messages")}
+                        tooltipPosition={TooltipPosition.BOTTOM}
                         icon
                         disabled={$activeChat.users.length === 0}
                         loading={loading}
@@ -469,6 +477,9 @@
                     </Button>
                     {#if $activeChat.kind === ChatType.Group}
                         <Button
+                            hook="button-chat-group-participants"
+                            tooltip={$_("chat.show-participants")}
+                            tooltipPosition={TooltipPosition.BOTTOM}
                             icon
                             appearance={showUsers ? Appearance.Primary : Appearance.Alt}
                             loading={loading}
@@ -478,6 +489,9 @@
                             <Icon icon={Shape.Users} />
                         </Button>
                         <Button
+                            hook="button-chat-group-settings"
+                            tooltip={$_("chat.group-settings")}
+                            tooltipPosition={TooltipPosition.BOTTOM}
                             icon
                             appearance={groupSettings ? Appearance.Primary : Appearance.Alt}
                             loading={loading}
@@ -678,6 +692,7 @@
                 <Controls>
                     <Button
                         hook="button-chat-transact"
+                        tooltip={$_("chat.send-coin")}
                         icon
                         outline
                         appearance={transact ? Appearance.Primary : Appearance.Alt}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Add tooltips for buttons displayed on top from chat (audio, video call, favorite, pinned, show members, settings)
- Add tooltip for send coin button
- Updated enum for tooltip position to allow passing bottom option
- Updated ButtonSvelte to allow using tooltip bottom css

After:

https://github.com/user-attachments/assets/413dac25-e760-4230-a282-8ffff0364257



### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
