### PR TITLE
chore(ci): run build preview and compare logs

### DIFF
--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -23,11 +23,15 @@ jobs:
         run: |
           npm run build > dev-build-log.txt 2>&1
 
+      - name: Normalize dev log
+        run: |
+          cat dev-build-log.txt | sed -E 's/[0-9]{2}:[0-9]{2}:[0-9]{2}//g' | tr -s ' ' > normalized-dev-log.txt
+
       - name: Save dev build log as artifact
         uses: actions/upload-artifact@v4
         with:
           name: dev-build-log
-          path: dev-build-log.txt
+          path: normalized-dev-log.txt
 
       - name: Checkout PR branch
         run: git checkout ${{ github.head_ref }}
@@ -39,25 +43,29 @@ jobs:
         run: |
           npm run build > pr-build-log.txt 2>&1
 
+      - name: Normalize PR log
+        run: |
+          cat pr-build-log.txt | sed -E 's/[0-9]{2}:[0-9]{2}:[0-9]{2}//g' | tr -s ' ' > normalized-pr-log.txt
+
       - name: Save PR build log as artifact
         uses: actions/upload-artifact@v4
         with:
           name: pr-build-log
-          path: pr-build-log.txt
+          path: normalized-pr-log.txt
 
       - name: Compare build logs
         run: |
           echo "Comparing build logs..."
-          diff dev-build-log.txt pr-build-log.txt > log-diff.txt || true
+          diff normalized-dev-log.txt normalized-pr-log.txt > log-diff.txt || true
           cat log-diff.txt
 
       - name: Annotate new warnings
         run: |
           echo "Checking for new warnings..."
-          NEW_WARNINGS=$(grep '^+.*warning' log-diff.txt || true)
+          NEW_WARNINGS=$(grep '^>.*warning' log-diff.txt || true)
           if [ -n "$NEW_WARNINGS" ]; then
             echo "$NEW_WARNINGS" | while IFS= read -r line; do
-              echo "::warning title=New Warning::${line#++}"
+              echo "::warning title=New Warning::${line#*>}"
             done
           else
             echo "No additional warnings found."

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -22,11 +22,15 @@ jobs:
       - name: Build project (dev branch) and save log
         run: npm run build > dev-build-log.txt 2>&1
 
-      - name: Save dev build log as artifact
+      - name: Extract relevant section from dev log
+        run: |
+          sed -n '/building for production.../,/modules transformed./p' dev-build-log.txt > relevant-dev-log.txt
+
+      - name: Save extracted dev log as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dev-build-log
-          path: dev-build-log.txt
+          name: relevant-dev-log
+          path: relevant-dev-log.txt
 
       - name: Checkout PR branch
         run: git checkout ${{ github.head_ref }}
@@ -37,17 +41,20 @@ jobs:
       - name: Build project (PR branch) and save log
         run: npm run build > pr-build-log.txt 2>&1
 
-      - name: Save PR build log as artifact
+      - name: Extract relevant section from PR log
+        run: |
+          sed -n '/building for production.../,/modules transformed./p' pr-build-log.txt > relevant-pr-log.txt
+
+      - name: Save extracted PR log as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pr-build-log
-          path: pr-build-log.txt
+          name: relevant-pr-log
+          path: relevant-pr-log.txt
 
-      - name: Compare build logs for any differences
+      - name: Compare extracted sections for differences
         run: |
-          echo "Comparing logs for differences..."
-          # Compare the logs and highlight the differences
-          diff dev-build-log.txt pr-build-log.txt > log-diff.txt || true
+          echo "Comparing relevant sections for differences..."
+          diff relevant-dev-log.txt relevant-pr-log.txt > log-diff.txt || true
 
           if [ -s log-diff.txt ]; then
             echo "::warning title=Differences Found::$(cat log-diff.txt | tr '\n' ' ')"

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   compare-build-logs:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: write
+      issues: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -60,7 +60,7 @@ jobs:
         id: diff_check
         run: |
           echo "Comparing relevant sections for differences..."
-          diff -u relevant-dev-log.txt relevant-pr-log.txt > log-diff.txt || true
+          diff relevant-dev-log.txt relevant-pr-log.txt > log-diff.txt || true
 
           if [ -s log-diff.txt ]; then
             echo "Differences detected."
@@ -76,14 +76,25 @@ jobs:
           name: build-log-diff
           path: log-diff.txt
 
+      - name: Read log-diff.txt content
+        id: read_diff
+        run: |
+          if [ -f log-diff.txt ]; then
+            echo "DIFF_CONTENT<<EOF" >> $GITHUB_ENV
+            cat log-diff.txt >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            echo "No diff file found." >> $GITHUB_ENV
+          fi
+
       - name: Comment PR with build log differences
         if: env.diff_found == 'true'
         uses: actions-ecosystem/action-create-comment@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            :warning: **Build Log Differences Found**:
+            **Build Log Differences Found**:
 
             ```diff
-            $(cat log-diff.txt)
+            ${{ env.DIFF_CONTENT }}
             ```

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -52,15 +52,17 @@ jobs:
           path: relevant-pr-log.txt
 
       - name: Compare extracted sections for differences
+        id: diff_check
         run: |
           echo "Comparing relevant sections for differences..."
           diff relevant-dev-log.txt relevant-pr-log.txt > log-diff.txt || true
 
           if [ -s log-diff.txt ]; then
-            echo "::warning title=Differences Found::$(cat log-diff.txt | tr '\n' ' ')"
             echo "Differences detected."
+            echo "::set-output name=diff_found::true"
           else
-            echo "No differences found."
+            echo "No differences found." > log-diff.txt
+            echo "::set-output name=diff_found::false"
           fi
 
       - name: Upload diff as artifact for review
@@ -68,3 +70,16 @@ jobs:
         with:
           name: build-log-diff
           path: log-diff.txt
+
+      - name: Comment PR with diff results
+        if: steps.diff_check.outputs.diff_found == 'true'
+        uses: mshick/add-pr-comment@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: |
+            **Build Log Differences Found**:
+
+            ```diff
+            $(cat log-diff.txt)
+            ```

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -64,10 +64,13 @@ jobs:
 
           if [ -s log-diff.txt ]; then
             echo "Differences detected."
-            echo "::set-output name=diff_found::true"
+            echo "diff_found=true" >> $GITHUB_ENV
+            # Extract the new warnings from the PR log
+            grep -Ff relevant-dev-log.txt relevant-pr-log.txt > new-warnings.txt || true
+            cat new-warnings.txt
           else
             echo "No differences found." > log-diff.txt
-            echo "::set-output name=diff_found::false"
+            echo "diff_found=false" >> $GITHUB_ENV
           fi
 
       - name: Upload diff as artifact for review
@@ -76,15 +79,17 @@ jobs:
           name: build-log-diff
           path: log-diff.txt
 
-      - name: Comment PR with diff results
-        if: steps.diff_check.outputs.diff_found == 'true'
-        uses: mshick/add-pr-comment@v2
+      - name: Comment PR with warning results
+        if: env.diff_found == 'true'
+        run: |
+          NEW_WARNINGS=$(cat new-warnings.txt)
+          COMMENT_BODY="**Build Log Differences Found**:\n\n${NEW_WARNINGS}"
+          PR_COMMENT_ID=$(gh pr view ${{ github.event.pull_request.number }} --json comments -q '.comments[] | select(.body | contains("Build Log Differences Found")) | .id')
+          
+          if [ -z "$PR_COMMENT_ID" ]; then
+            gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"
+          else
+            gh api --method PATCH /repos/${{ github.repository }}/issues/comments/$PR_COMMENT_ID --field body="$COMMENT_BODY"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          message: |
-            **Build Log Differences Found**:
-
-            ```diff
-            $(cat log-diff.txt)
-            ```

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -43,25 +43,21 @@ jobs:
           name: pr-build-log
           path: pr-build-log.txt
 
-      - name: Find differences in warnings
+      - name: Compare build logs for any differences
         run: |
-          echo "Extracting warnings from logs..."
-          grep -i "warning" dev-build-log.txt > dev-warnings.txt || true
-          grep -i "warning" pr-build-log.txt > pr-warnings.txt || true
+          echo "Comparing logs for differences..."
+          # Compare the logs and highlight the differences
+          diff dev-build-log.txt pr-build-log.txt > log-diff.txt || true
 
-          echo "Checking for new warnings in PR..."
-          comm -13 dev-warnings.txt pr-warnings.txt > new-warnings.txt || true
-
-          if [ -s new-warnings.txt ]; then
-            echo "New warnings found:"
-            cat new-warnings.txt
-            echo "::warning title=New Warnings Found::$(cat new-warnings.txt | tr '\n' ' ')"
+          if [ -s log-diff.txt ]; then
+            echo "::warning title=Differences Found::$(cat log-diff.txt | tr '\n' ' ')"
+            echo "Differences detected."
           else
-            echo "No new warnings found."
+            echo "No differences found."
           fi
 
       - name: Upload diff as artifact for review
         uses: actions/upload-artifact@v4
         with:
-          name: new-warnings
-          path: new-warnings.txt
+          name: build-log-diff
+          path: log-diff.txt

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -1,0 +1,61 @@
+name: Compare Build Logs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  compare-build-logs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for accurate comparisons
+
+      - name: Checkout dev branch
+        run: git checkout dev
+
+      - name: Install dependencies (dev branch)
+        run: npm install
+
+      - name: Build project (dev branch)
+        run: |
+          npm run build 2>&1 | tee dev-build-log.txt
+
+      - name: Save dev build log as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-build-log
+          path: dev-build-log.txt
+
+      - name: Checkout PR branch
+        run: git checkout ${{ github.head_ref }}
+
+      - name: Install dependencies (PR branch)
+        run: npm install
+
+      - name: Build project (PR branch)
+        run: |
+          npm run build 2>&1 | tee pr-build-log.txt
+
+      - name: Save PR build log as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-build-log
+          path: pr-build-log.txt
+
+      - name: Compare build logs
+        run: |
+          echo "Differences between dev and PR build logs:"
+          diff -u dev-build-log.txt pr-build-log.txt || true
+
+      - name: Annotate warnings
+        if: success()
+        run: |
+          WARNINGS=$(diff -u dev-build-log.txt pr-build-log.txt | grep '^+' | grep -i 'warning' || true)
+          if [ -n "$WARNINGS" ]; then
+            echo "::warning title=Build Warnings::${WARNINGS}"
+          else
+            echo "No additional warnings found."
+          fi

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Extract relevant section from dev log
         run: |
-          sed -n '/building for production.../,/modules transformed./p' dev-build-log.txt > relevant-dev-log.txt
+          sed -n '/building for production.../,/modules transformed./p' dev-build-log.txt | grep -v "modules transformed." > relevant-dev-log.txt
 
       - name: Save extracted dev log as artifact
         uses: actions/upload-artifact@v4
@@ -43,7 +43,7 @@ jobs:
 
       - name: Extract relevant section from PR log
         run: |
-          sed -n '/building for production.../,/modules transformed./p' pr-build-log.txt > relevant-pr-log.txt
+          sed -n '/building for production.../,/modules transformed./p' pr-build-log.txt | grep -v "modules transformed." > relevant-pr-log.txt
 
       - name: Save extracted PR log as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Fetch all history for accurate comparisons
+          fetch-depth: 0  # Fetch all history for accurate comparisons
 
       - name: Checkout dev branch
         run: git checkout dev
@@ -20,18 +20,13 @@ jobs:
         run: npm install
 
       - name: Build project (dev branch) and save log
-        run: |
-          npm run build > dev-build-log.txt 2>&1
-
-      - name: Normalize dev log
-        run: |
-          cat dev-build-log.txt | sed -E 's/[0-9]{2}:[0-9]{2}:[0-9]{2}//g' | tr -s ' ' > normalized-dev-log.txt
+        run: npm run build > dev-build-log.txt 2>&1
 
       - name: Save dev build log as artifact
         uses: actions/upload-artifact@v4
         with:
           name: dev-build-log
-          path: normalized-dev-log.txt
+          path: dev-build-log.txt
 
       - name: Checkout PR branch
         run: git checkout ${{ github.head_ref }}
@@ -40,33 +35,33 @@ jobs:
         run: npm install
 
       - name: Build project (PR branch) and save log
-        run: |
-          npm run build > pr-build-log.txt 2>&1
-
-      - name: Normalize PR log
-        run: |
-          cat pr-build-log.txt | sed -E 's/[0-9]{2}:[0-9]{2}:[0-9]{2}//g' | tr -s ' ' > normalized-pr-log.txt
+        run: npm run build > pr-build-log.txt 2>&1
 
       - name: Save PR build log as artifact
         uses: actions/upload-artifact@v4
         with:
           name: pr-build-log
-          path: normalized-pr-log.txt
+          path: pr-build-log.txt
 
-      - name: Compare build logs
+      - name: Find differences in warnings
         run: |
-          echo "Comparing build logs..."
-          diff normalized-dev-log.txt normalized-pr-log.txt > log-diff.txt || true
-          cat log-diff.txt
+          echo "Extracting warnings from logs..."
+          grep -i "warning" dev-build-log.txt > dev-warnings.txt || true
+          grep -i "warning" pr-build-log.txt > pr-warnings.txt || true
 
-      - name: Annotate new warnings
-        run: |
-          echo "Checking for new warnings..."
-          NEW_WARNINGS=$(grep '^>.*warning' log-diff.txt || true)
-          if [ -n "$NEW_WARNINGS" ]; then
-            echo "$NEW_WARNINGS" | while IFS= read -r line; do
-              echo "::warning title=New Warning::${line#*>}"
-            done
+          echo "Checking for new warnings in PR..."
+          comm -13 dev-warnings.txt pr-warnings.txt > new-warnings.txt || true
+
+          if [ -s new-warnings.txt ]; then
+            echo "New warnings found:"
+            cat new-warnings.txt
+            echo "::warning title=New Warnings Found::$(cat new-warnings.txt | tr '\n' ' ')"
           else
-            echo "No additional warnings found."
+            echo "No new warnings found."
           fi
+
+      - name: Upload diff as artifact for review
+        uses: actions/upload-artifact@v4
+        with:
+          name: new-warnings
+          path: new-warnings.txt

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Install dependencies (dev branch)
         run: npm install
 
-      - name: Build project (dev branch)
+      - name: Build project (dev branch) and save log
         run: |
-          npm run build 2>&1 | tee dev-build-log.txt
+          npm run build > dev-build-log.txt 2>&1
 
       - name: Save dev build log as artifact
         uses: actions/upload-artifact@v4
@@ -35,9 +35,9 @@ jobs:
       - name: Install dependencies (PR branch)
         run: npm install
 
-      - name: Build project (PR branch)
+      - name: Build project (PR branch) and save log
         run: |
-          npm run build 2>&1 | tee pr-build-log.txt
+          npm run build > pr-build-log.txt 2>&1
 
       - name: Save PR build log as artifact
         uses: actions/upload-artifact@v4
@@ -47,15 +47,18 @@ jobs:
 
       - name: Compare build logs
         run: |
-          echo "Differences between dev and PR build logs:"
-          diff -u dev-build-log.txt pr-build-log.txt || true
+          echo "Comparing build logs..."
+          diff dev-build-log.txt pr-build-log.txt > log-diff.txt || true
+          cat log-diff.txt
 
-      - name: Annotate warnings
-        if: success()
+      - name: Annotate new warnings
         run: |
-          WARNINGS=$(diff -u dev-build-log.txt pr-build-log.txt | grep '^+' | grep -i 'warning' || true)
-          if [ -n "$WARNINGS" ]; then
-            echo "::warning title=Build Warnings::${WARNINGS}"
+          echo "Checking for new warnings..."
+          NEW_WARNINGS=$(grep '^+.*warning' log-diff.txt || true)
+          if [ -n "$NEW_WARNINGS" ]; then
+            echo "$NEW_WARNINGS" | while IFS= read -r line; do
+              echo "::warning title=New Warning::${line#++}"
+            done
           else
             echo "No additional warnings found."
           fi

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Extract relevant section from PR log
         run: |
-          sed -n '/building for production.../,/modules transformed./p' pr-build-log.txt | grep -v "modules transformed." > relevant-pr-log.txt
+          sed -n '/building for production.../,/modules transformed./p' pr-build-log.txt > relevant-pr-log.txt
 
       - name: Save extracted PR log as artifact
         uses: actions/upload-artifact@v4
@@ -60,14 +60,11 @@ jobs:
         id: diff_check
         run: |
           echo "Comparing relevant sections for differences..."
-          diff relevant-dev-log.txt relevant-pr-log.txt > log-diff.txt || true
+          diff -u relevant-dev-log.txt relevant-pr-log.txt > log-diff.txt || true
 
           if [ -s log-diff.txt ]; then
             echo "Differences detected."
             echo "diff_found=true" >> $GITHUB_ENV
-            # Extract the new warnings from the PR log
-            grep -Ff relevant-dev-log.txt relevant-pr-log.txt > new-warnings.txt || true
-            cat new-warnings.txt
           else
             echo "No differences found." > log-diff.txt
             echo "diff_found=false" >> $GITHUB_ENV
@@ -79,17 +76,14 @@ jobs:
           name: build-log-diff
           path: log-diff.txt
 
-      - name: Comment PR with warning results
+      - name: Comment PR with build log differences
         if: env.diff_found == 'true'
-        run: |
-          NEW_WARNINGS=$(cat new-warnings.txt)
-          COMMENT_BODY="**Build Log Differences Found**:\n\n${NEW_WARNINGS}"
-          PR_COMMENT_ID=$(gh pr view ${{ github.event.pull_request.number }} --json comments -q '.comments[] | select(.body | contains("Build Log Differences Found")) | .id')
-          
-          if [ -z "$PR_COMMENT_ID" ]; then
-            gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"
-          else
-            gh api --method PATCH /repos/${{ github.repository }}/issues/comments/$PR_COMMENT_ID --field body="$COMMENT_BODY"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions-ecosystem/action-create-comment@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            :warning: **Build Log Differences Found**:
+
+            ```diff
+            $(cat log-diff.txt)
+            ```

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Extract relevant section from dev log
         run: |
-          sed -n '/building for production.../,/modules transformed./p' dev-build-log.txt | grep -v "modules transformed." > relevant-dev-log.txt
+          sed -n '/building for production.../,/modules transformed./p' dev-build-log.txt > relevant-dev-log.txt
 
       - name: Save extracted dev log as artifact
         uses: actions/upload-artifact@v4

--- a/src/app.scss
+++ b/src/app.scss
@@ -170,7 +170,7 @@ select {
 
 @font-face {
     font-family: "NotoEmoji";
-    src: url("/assets/emoji/NotoEmoji.ttf");
+    src: url("/assets/emoji/NotoColorEmoji.ttf");
 }
 
 @font-face {

--- a/src/app.scss
+++ b/src/app.scss
@@ -170,7 +170,7 @@ select {
 
 @font-face {
     font-family: "NotoEmoji";
-    src: url("/assets/emoji/NotoColorEmoji.ttf");
+    src: url("/assets/emoji/NotoEmoji.ttf");
 }
 
 @font-face {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖


Adds CI for the following:
- `npm run build` on `dev` branch and grabs log
- `npm run build` on PR branch and grabs log
- compares both logs to see if there is additional warnings
- adds comment on the PR with the additional warning

<img width="976" alt="Captura de ecrã 2024-08-31, às 16 07 41" src="https://github.com/user-attachments/assets/08228790-80ba-4906-afce-d8fed84541d8">


