### PR TITLE
chore(warning): fix warp warning

### DIFF
--- a/src/lib/wasm/HandleWarpErrors.ts
+++ b/src/lib/wasm/HandleWarpErrors.ts
@@ -14,6 +14,7 @@ export enum WarpError {
     MULTIPASS_NOT_FOUND = "Multipass instance not found",
     CONSTELLATION_NOT_FOUND = "Constellation instance not found",
     RAYGUN_NOT_FOUND = "Raygun instance not found",
+    FILE_SIZE_EXCEEDED = "File size exceeded",
 }
 
 export function handleErrors(error: any): WarpError {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Fix the following warning
<img width="613" alt="Captura de ecrã 2024-09-02, às 21 05 22" src="https://github.com/user-attachments/assets/e0cfa8a5-2e37-4fe0-ba10-d434f697e704">

How to test
- npm run check
- the above error should not appear and the behavior should be the same as dev