### PR TITLE
fix(state): db error

### DIFF
--- a/src/lib/state/db/dbOperations.ts
+++ b/src/lib/state/db/dbOperations.ts
@@ -4,6 +4,15 @@ const storeName = "stateStore"
 const dbName = "UplinkAppState"
 
 export async function initDB(): Promise<IDBDatabase> {
+    // During e.g. a page refresh initDB() is called too fast and the constants are uninitialized. This is a workaround for that
+    while (true) {
+        try {
+            let _ = dbName
+            break
+        } catch (e) {
+            await new Promise(f => setTimeout(f, 5))
+        }
+    }
     return new Promise((resolve, reject) => {
         const request = indexedDB.open(dbName, 1)
 
@@ -66,7 +75,7 @@ export async function getStateFromDB<T>(key: string, defaultState: T): Promise<T
             }
         })
     } catch (error) {
-        log.error(`Error initializing DB for getting state. Error: ${error}`)
+        log.error(`Error initializing DB for getting state ${key}. Error: ${error}`)
         return defaultState
     }
 }
@@ -89,7 +98,7 @@ export async function setStateToDB<T>(key: string, state: T): Promise<void> {
             }
         })
     } catch (error) {
-        log.error(`Error initializing DB for setting state. Error: ${error}`)
+        log.error(`Error initializing DB for setting state ${key}. Error: ${error}`)
         throw new Error("Error writing to DB")
     }
 }


### PR DESCRIPTION
### What this PR does 📖

- During a page refresh the constants in the db are not initialized when accessed causing an error for the first access of it. (first time only). This tries to see if the constant is initialized before continuuing
