### PR TITLE
fix(Sidebar): Sort chats on sidebar according with datetime last message sent or received

### DIFF
--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -366,7 +366,11 @@
             </Button>
         </div>
 
-        {#each $chats as chat}
+        {#each $chats.slice().sort((a, b) => {
+            const dateA = new Date(a.last_message_at || 0)
+            const dateB = new Date(b.last_message_at || 0)
+            return dateB.getTime() - dateA.getTime()
+        }) as chat}
             <ContextMenu
                 hook="context-menu-sidebar-chat"
                 items={[


### PR DESCRIPTION
### What this PR does 📖

#### 1. Sort chats on sidebar according with datetime last message sent or received

https://github.com/user-attachments/assets/c9206026-952c-4956-b3cb-2b3d461c298d

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
