### PR TITLE
fix(Chat): Fix remove reaction when user select exactly the same emoji

### DIFF
--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -625,7 +625,7 @@
                                                 {/if}
                                             </Message>
                                             <svelte:fragment slot="items" let:close>
-                                                <EmojiGroup emojis={$emojis} emojiPick={emoji => reactTo(message.id, emoji, false)} close={close} on:openPicker={_ => (reactingTo = message.id)}></EmojiGroup>
+                                                <EmojiGroup emojis={$emojis} emojiPick={emoji => reactTo(message.id, emoji, true)} close={close} on:openPicker={_ => (reactingTo = message.id)}></EmojiGroup>
                                             </svelte:fragment>
                                         </ContextMenu>
                                     {/if}
@@ -673,7 +673,7 @@
                 typing={$activeChat.typing_indicator.users && $activeChat.typing_indicator.users().map(u => $users[u])}
                 emojiClickHook={emoji => {
                     if (reactingTo) {
-                        reactTo(reactingTo, emoji, false)
+                        reactTo(reactingTo, emoji, true)
                         reactingTo = undefined
                         return true
                     }


### PR DESCRIPTION
### What this PR does 📖

#### 1. Fix remove reaction when user select exactly the same emoji


https://github.com/user-attachments/assets/728cbf5c-a78b-45aa-904a-27b0dd9d6807




### Which issue(s) this PR fixes 🔨

- Resolve #495 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
