### PR TITLE
fix(UI): Fix Windows Dropdown Background

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -65,6 +65,10 @@ select {
     font: inherit;
 }
 
+select option {
+    background: var(--alt-color);
+}
+
 /* Remove all animations, transitions and smooth scroll for people that prefer not to see them */
 @media (prefers-reduced-motion: reduce) {
     html:focus-within {

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -115,7 +115,3 @@
     --sticker-width: 8.5rem;
     --sticker-width-rendered: 18rem;
 }
-
-select option {
-    background: var(--alt-color);
-}

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -117,5 +117,5 @@
 }
 
 select option {
-    background: var(--background);
+    background: var(--alt-color);
 }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -115,3 +115,7 @@
     --sticker-width: 8.5rem;
     --sticker-width-rendered: 18rem;
 }
+
+select option {
+    background: var(--background);
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- The dropdown menus on Windows have looked messed up for a while. The background coloring has always been white despite changing themes, while the text changes color with the theme. Now the Background of the dropdown menus mirror the background of the app. I have not tested on Mac or Linux.

### Which issue(s) this PR fixes 🔨

- Resolve #N/A

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
