### PR TITLE
fix(Emoji): Let emojis aligned to the left when filtered

### DIFF
--- a/src/lib/components/messaging/emoji/EmojiSelector.svelte
+++ b/src/lib/components/messaging/emoji/EmojiSelector.svelte
@@ -243,7 +243,7 @@
                 .emoji-list {
                     display: flex;
                     flex-wrap: wrap;
-                    justify-content: space-between;
+                    justify-content: left;
                     gap: var(--gap-less);
 
                     .emoji {


### PR DESCRIPTION
### What this PR does 📖

- Let emojis aligned to the left when filtered
![image](https://github.com/user-attachments/assets/980544ef-7b94-4766-bf02-d736a906c813)


### Which issue(s) this PR fixes 🔨

- Resolve #589 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
