### PR TITLE
fix(chat): fix pasting converting emoji when undesired

### DIFF
--- a/src/lib/components/messaging/emoji/EmojiList.ts
+++ b/src/lib/components/messaging/emoji/EmojiList.ts
@@ -19,3 +19,21 @@ export const emojiList = {
     symbols,
     flags,
 }
+
+class EmojiRegex {
+    private regex: { [i: string]: RegExp } = {}
+
+    private escapeRegExp(input: string) {
+        return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") // Escape special characters
+    }
+    getRegexFor(emoji: { name: string; glyph: string; text: string; shortname: string }): RegExp {
+        let regex = this.regex[emoji.shortname]
+        if (!regex) {
+            regex = new RegExp(`(${this.escapeRegExp(emoji.shortname)}|${this.escapeRegExp(emoji.text)})( |$)`)
+            this.regex[emoji.shortname] = regex
+        }
+        return regex
+    }
+}
+
+export const emojiRegexMap = new EmojiRegex()

--- a/src/lib/layouts/Chatbar.svelte
+++ b/src/lib/layouts/Chatbar.svelte
@@ -16,7 +16,7 @@
     import CombinedSelector from "$lib/components/messaging/CombinedSelector.svelte"
     import { checkMobile } from "$lib/utils/Mobile"
     import { UIStore } from "$lib/state/ui"
-    import { emojiList } from "$lib/components/messaging/emoji/EmojiList"
+    import { emojiList, emojiRegexMap } from "$lib/components/messaging/emoji/EmojiList"
     import { tempCDN } from "$lib/utils/CommonVariables"
     import AudioEmbed from "$lib/components/messaging/embeds/AudioEmbed.svelte"
     import VideoEmbed from "$lib/components/messaging/embeds/VideoEmbed.svelte"
@@ -25,6 +25,7 @@
     import { VoiceRTCMessageType } from "$lib/media/Voice"
     import Text from "$lib/elements/Text.svelte"
     import StoreResolver from "$lib/components/utils/StoreResolver.svelte"
+    import { emojiRegex } from "$lib/components/utils/Emoji"
 
     export let replyTo: MessageType | undefined = undefined
     export let filesSelected: [File?, string?][] = []
@@ -125,12 +126,9 @@
         let isThereEmoji = false
 
         emojiList.smileys_and_emotion.forEach(emoji => {
-            if (emoji.text && result.includes(emoji.text)) {
-                result = result.replaceAll(emoji.text, emoji.glyph)
-                isThereEmoji = true
-            }
-            if (emoji.shortname && result.includes(emoji.shortname)) {
-                result = result.replaceAll(emoji.shortname, emoji.glyph)
+            let reg = emojiRegexMap.getRegexFor(emoji)
+            if (result.match(reg)) {
+                result = result.replace(reg, _ => emoji.glyph)
                 isThereEmoji = true
             }
         })


### PR DESCRIPTION
### What this PR does 📖

- Makes the emoji replacement ignore when the supposed emoji is not followed by a whitespace or lineend. Solves pasting links converting emojis

### Which issue(s) this PR fixes 🔨

- Resolve #601