### PR TITLE
fix(friends): change friend toast click

### DIFF
--- a/src/lib/state/Store.ts
+++ b/src/lib/state/Store.ts
@@ -46,6 +46,7 @@ class GlobalStore {
             openFolders: createPersistentState<Record<string, boolean>>("uplink.openFolders", {}),
             toasts: writable({}),
             userCache: writable({}),
+            pageState: writable(""),
         }
     }
 

--- a/src/lib/state/initial.ts
+++ b/src/lib/state/initial.ts
@@ -26,4 +26,5 @@ export interface IState {
     // A cache of all fetched user data
     // We use a Writable<User> to also allow easy subscription to changes if only that user interests us
     userCache: Writable<{ [key: string]: Writable<User> }>
+    pageState: Writable<string>
 }

--- a/src/lib/wasm/MultipassStore.ts
+++ b/src/lib/wasm/MultipassStore.ts
@@ -74,7 +74,8 @@ class MultipassStore {
                             if (incoming) {
                                 Store.addToastNotification(
                                     new ToastMessage("New friend request.", `${incoming?.name} sent a request.`, 2, undefined, undefined, () => {
-                                        goto(Route.Friends, { state: { tab: "active" } })
+                                        goto(Route.Friends)
+                                        Store.state.pageState.set("active")
                                     }),
                                     Sounds.Notification
                                 )
@@ -82,7 +83,8 @@ class MultipassStore {
                             } else {
                                 Store.addToastNotification(
                                     new ToastMessage("New friend request.", `You received a new friend request.`, 2, undefined, undefined, () => {
-                                        goto(Route.Friends, { state: { tab: "active" } })
+                                        goto(Route.Friends)
+                                        Store.state.pageState.set("active")
                                     }),
                                     Sounds.Notification
                                 )
@@ -595,7 +597,7 @@ class MultipassStore {
                             overlay: "",
                         },
                         status: status,
-                        status_message: identity === undefined ? "" : identity.status_message ?? "",
+                        status_message: identity === undefined ? "" : (identity.status_message ?? ""),
                     },
                     integrations: identity === undefined ? new Map<string, string>() : identity.metadata,
                     media: {

--- a/src/routes/friends/+page.svelte
+++ b/src/routes/friends/+page.svelte
@@ -18,8 +18,8 @@
     import { RaygunStoreInstance } from "$lib/wasm/RaygunStore"
     import { ToastMessage } from "$lib/state/ui/toast"
     import { CommonInputRules } from "$lib/utils/CommonInputRules"
-    import { page } from "$app/stores"
     import CreateGroup from "$lib/components/group/CreateGroup.svelte"
+    import { onDestroy } from "svelte"
 
     let loading: boolean = false
     $: sidebarOpen = UIStore.state.sidebarOpen
@@ -33,12 +33,18 @@
 
     let tab: "all" | "active" | "blocked" = "all"
 
-    $: {
-        let state = $page.state as any
-        if (state.tab) {
-            tab = state.tab
+    let unsub = Store.state.pageState.subscribe(s => {
+        function isTab(value: string): value is "all" | "active" | "blocked" {
+            return value === "all" || value === "active" || value === "blocked"
         }
-    }
+        if (isTab(s)) {
+            tab = s
+        }
+    })
+
+    onDestroy(() => {
+        unsub()
+    })
 
     function toggleSidebar(): void {
         UIStore.toggleSidebar()


### PR DESCRIPTION
### What this PR does 📖

- Changes friend toast notification on click. The cause of the error in the linked PR was caused by following:
  - If you are already on friends page clicking on toast will do nothing.
  - If you arent then you were brought to the friends page with the subpage set to incoming requests

### Which issue(s) this PR fixes 🔨

- Resolve #608