### PR TITLE
fix(CreateAccount): Hide import account and change users buttons

### DIFF
--- a/src/lib/layouts/login/Entrypoint.svelte
+++ b/src/lib/layouts/login/Entrypoint.svelte
@@ -11,6 +11,8 @@
     import RelaySelector from "$lib/components/ui/RelaySelector.svelte"
     import { Controls } from "$lib/layouts"
     import { LoginPage } from "$lib/layouts/login"
+    import { SettingsStore } from "$lib/state"
+    import { get } from "svelte/store"
 
     export let page: LoginPage
 
@@ -61,9 +63,11 @@
             <Button text={$_("pages.auth.create.new")} hook="button-create-account" on:click={_ => (page = LoginPage.Username)} appearance={Appearance.Primary} fill>
                 <Icon icon={Shape.Plus} />
             </Button>
-            <Button text={$_("pages.auth.create.import")} hook="button-import-account" on:click={_ => (showConfigureRelay = true)} appearance={Appearance.Alt} fill>
-                <Icon icon={Shape.ArrowUp} />
-            </Button>
+            {#if get(SettingsStore.state).devmode}
+                <Button text={$_("pages.auth.create.import")} hook="button-import-account" on:click={_ => (showConfigureRelay = true)} appearance={Appearance.Alt} fill>
+                    <Icon icon={Shape.ArrowUp} />
+                </Button>
+            {/if}
         </Controls>
     </div>
 

--- a/src/lib/layouts/login/Entrypoint.svelte
+++ b/src/lib/layouts/login/Entrypoint.svelte
@@ -73,9 +73,11 @@
 
     <div class="unlock-controls">
         <Controls>
-            <Button tooltip={$_("pages.auth.changeUser")} hook="button-change-user" icon on:click={_ => (showAccounts = true)} appearance={Appearance.Alt}>
-                <Icon icon={Shape.Profile} />
-            </Button>
+            {#if get(SettingsStore.state).devmode}
+                <Button tooltip={$_("pages.auth.changeUser")} hook="button-change-user" icon on:click={_ => (showAccounts = true)} appearance={Appearance.Alt}>
+                    <Icon icon={Shape.Profile} />
+                </Button>
+            {/if}
             <Button tooltip={$_("pages.auth.relay")} hook="button-configure-relay" icon on:click={_ => (showConfigureRelay = true)} appearance={Appearance.Alt}>
                 <Icon icon={Shape.Relay} />
             </Button>

--- a/src/lib/layouts/login/Unlock.svelte
+++ b/src/lib/layouts/login/Unlock.svelte
@@ -13,6 +13,7 @@
     import { Controls } from "$lib/layouts"
     import { AuthStore } from "$lib/state/auth"
     import { createEventDispatcher } from "svelte"
+    import { SettingsStore } from "$lib/state"
 
     export let create: boolean = false
 
@@ -76,9 +77,11 @@
 
     <div class="unlock-controls">
         <Controls>
-            <Button tooltip={$_("pages.auth.changeUser")} hook="button-change-user" icon on:click={_ => (showAccounts = true)} appearance={Appearance.Alt}>
-                <Icon icon={Shape.Profile} />
-            </Button>
+            {#if get(SettingsStore.state).devmode}
+                <Button tooltip={$_("pages.auth.changeUser")} hook="button-change-user" icon on:click={_ => (showAccounts = true)} appearance={Appearance.Alt}>
+                    <Icon icon={Shape.Profile} />
+                </Button>
+            {/if}
             <Button tooltip={$_("pages.auth.relay")} hook="button-configure-relay" icon on:click={_ => (showConfigureRelay = true)} appearance={Appearance.Alt}>
                 <Icon icon={Shape.Relay} />
             </Button>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Hide import account and change users buttons and just show them if devmode is enabled

### Which issue(s) this PR fixes 🔨

- Resolve #619 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
