### PR TITLE
fix(previews): add checks to create payment preview messages

### DIFF
--- a/src/lib/components/messaging/ChatPreview.svelte
+++ b/src/lib/components/messaging/ChatPreview.svelte
@@ -11,11 +11,9 @@
     import { get } from "svelte/store"
     import { tempCDN } from "$lib/utils/CommonVariables"
     import { UIStore } from "$lib/state/ui"
-    import { t } from "svelte-i18n"
+    import { _ } from "svelte-i18n"
     import { checkMobile } from "$lib/utils/Mobile"
-    import Page from "../../../routes/+page.svelte"
     import { ConversationStore } from "$lib/state/conversation"
-    import { MultipassStoreInstance } from "$lib/wasm/MultipassStore"
 
     export let chat: Chat
     export let cta: boolean = false
@@ -36,9 +34,9 @@
     let ownId = get(Store.state.user)
     $: messagePreview =
         chat.last_message_id === ""
-            ? "No messages sent yet."
+            ? $_("message_previews.none")
             : chat.last_message_id !== "" && chat.last_message_preview === ""
-              ? "New Attachment"
+              ? $_("message_previews.attachment")
               : chat.last_message_preview.startsWith("/request")
                 ? (() => {
                       try {
@@ -47,9 +45,9 @@
                           const request = JSON.parse(chat.last_message_preview.slice(8))
                           const { amountPreview } = request
                           if (sendingUserId !== ownId.key) {
-                              return `${sendingUserDetails.name} has requested ${amountPreview}`
+                              return $_("message_previews.coin_requested", { values: { username: sendingUserDetails.name, amount: amountPreview } })
                           } else {
-                              return `You sent a request for ${amountPreview}`
+                              return $_("message_previews.request_sent", { values: { amount: amountPreview } })
                           }
                       } catch (error) {
                           return "Invalid message format"
@@ -61,13 +59,9 @@
         const date: Date = typeof dateInput === "string" ? new Date(dateInput) : dateInput
         return timeAgo.format(date)
     }
-    // $: {
-    //     console.log(chat.last_message_preview, chat)
-    // }
 
     onMount(() => {
         setInterval(() => {
-            // console.log(chat.last_message_preview)
             timeago = getTimeAgo(chat.last_message_at)
         }, 500)
     })

--- a/src/lib/lang/en.json
+++ b/src/lib/lang/en.json
@@ -137,6 +137,12 @@
         "pinnedUnpin": "Unpin",
         "pinnedNone": "There are no pinned messages in this chat"
     },
+    "message_previews": {
+        "none": "No messages sent yet",
+        "attachment": "New attachment",
+        "coin_requested": "{username} has requested {amount}",
+        "request_sent": "You sent a request for {amount}"
+    },
     "friends": {
         "copy_did": "Copy ID",
         "block": "Block",

--- a/src/lib/lang/en.json
+++ b/src/lib/lang/en.json
@@ -138,7 +138,7 @@
         "pinnedNone": "There are no pinned messages in this chat"
     },
     "message_previews": {
-        "none": "No messages sent yet",
+        "none": "No messages sent yet.",
         "attachment": "New attachment",
         "coin_requested": "{username} has requested {amount}",
         "request_sent": "You sent a request for {amount}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Add extra checks for message previews to include payments, add translations for the preview texts

### Which issue(s) this PR fixes 🔨

- Resolve #552 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

Big thing I was looking to do is have the messages apply correctly for who sent, and who is receiving and using the correct grammar depending on who sent/received

![image](https://github.com/user-attachments/assets/f311044d-7b7f-4b99-a4d6-0ecf0f07614e)


### Additional comments 🎤
