### PR TITLE
update(fix): fix deprecation warnings on build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -25,6 +25,7 @@ export default defineConfig({
     resolve: {
         alias: {
             $lib: path.resolve(__dirname, "src/lib"),
+            "@": path.resolve(__dirname, "src"),
         },
     },
     plugins: [
@@ -43,7 +44,11 @@ export default defineConfig({
     css: {
         preprocessorOptions: {
             scss: {
-                additionalData: '@use "src/variables.scss" as *;',
+                additionalData: '@use "@/variables.scss" as *;',
+                api: "modern-compiler",
+                importers: [
+                    // ...
+                ],
             },
         },
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Fixing the cause of the warning depreacation alerts when doing `npm run build`

Now:
![image](https://github.com/user-attachments/assets/565a512d-f8af-44c5-9ed1-46b8ed9f2cef)

Before:
![image](https://github.com/user-attachments/assets/9e67078b-94d3-48cb-af2b-7717bc99ebb9)


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
