### PR TITLE
chore(relay): fix warning

### DIFF
--- a/src/lib/components/ui/RelaySelector.svelte
+++ b/src/lib/components/ui/RelaySelector.svelte
@@ -284,10 +284,6 @@
             }
         }
 
-        .filling {
-            width: 100%;
-        }
-
         .error {
             font-size: var(--font-size-smallest);
             color: var(--error-color);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

fix warning on `npm run dev`

how to test
- npm run build
- this warning should not appear

<img width="815" alt="Captura de ecrã 2024-10-08, às 23 39 20" src="https://github.com/user-attachments/assets/3573597e-1562-4211-8082-398cefeae6e8">


- relay stuff should be the same as dev
