### PR TITLE
fix(IncomingCall): Improve spaces when status message is empty on IncomingCall component

### DIFF
--- a/src/lib/components/calling/IncomingCall.svelte
+++ b/src/lib/components/calling/IncomingCall.svelte
@@ -52,8 +52,10 @@
             <div class="content">
                 <ProfilePicture id={$user.key} hook="friend-profile-picture" size={Size.Large} image={$user.profile.photo.image} status={$user.profile.status} />
                 <Text>{$user.name}</Text>
-                <Text muted>{$user.profile.status_message}</Text>
-                <Spacer />
+                {#if $user.profile.status_message !== ""}
+                    <Text muted>{$user.profile.status_message}</Text>
+                {/if}
+                <Spacer less={true} />
                 <Controls>
                     <Button appearance={Appearance.Success} text="Answer" on:click={answerCall}>
                         <Icon icon={Shape.PhoneCall} />


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Improve spaces when status message is empty on IncomingCall component

1. Before fix: 
<img width="214" alt="image" src="https://github.com/user-attachments/assets/1bb7b307-950f-4008-ae93-14e89f48e8c8">

2. After fix: 
<img width="188" alt="image" src="https://github.com/user-attachments/assets/b4f203c7-cf82-4d2c-9446-593a5d73ebc4">


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
