### PR TITLE
update(ci): fix publish report bug

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -123,6 +123,8 @@ jobs:
             pull-requests: write
             contents: write
             issues: read
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}
         steps:
             - name: Download Merged Report
               uses: actions/download-artifact@v4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- After rerunning the automation tests there is a bug happening constantly on the publish report steps,  I did some research on the action itself and found that we need to pass the concurrency group to avoid this issue https://github.com/peaceiris/actions-gh-pages/issues/998#issuecomment-1742383037 - Also, all the examples included in the action readme have this step added in workflow, so I am trying it in here to see if that helps to avoid this annoying bug
![image](https://github.com/user-attachments/assets/5c8bd6fa-9d21-4e5b-9695-782bf117cd9a)


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
