### PR TITLE
update(ui): Redo reply ui

### DIFF
--- a/src/lib/components/messaging/MessageReplyContainer.svelte
+++ b/src/lib/components/messaging/MessageReplyContainer.svelte
@@ -4,14 +4,15 @@
 
     export let remote: boolean = false
     export let image: string = ""
+    export let first: boolean = false
 </script>
 
-<div class="message-reply-container {remote ? 'remote' : ''}">
-    {#if remote}
+<div class="message-reply-container {remote ? 'remote' : ''} {first ? 'first' : ''}">
+    {#if !remote}
         <ProfilePicture size={Size.Smallest} image={image} />
     {/if}
     <slot></slot>
-    {#if !remote}
+    {#if remote}
         <ProfilePicture size={Size.Smallest} image={image} />
     {/if}
 </div>
@@ -27,10 +28,37 @@
         align-items: center;
         gap: var(--gap);
         justify-content: flex-end;
-        padding-right: 24px;
+
+        &.first {
+            margin-right: var(--profile-picture-size);
+            margin-bottom: var(--gap-less);
+            position: relative;
+            position: relative;
+            &.remote {
+                margin-right: calc(-1 * var(--profile-picture-size));
+            }
+            &::before {
+                content: "";
+                position: absolute;
+                width: calc(0.5 * var(--profile-picture-size));
+                height: 50%;
+                border-style: solid;
+                border-color: var(--alt-color-alt);
+                border-width: var(--border-width-more) var(--border-width-more) 0 0;
+                border-radius: 0 var(--border-radius) 0 0;
+                top: 50%;
+                right: calc(-0.5 * var(--profile-picture-size) - var(--gap-less));
+            }
+        }
 
         &.remote {
             padding-right: 0px;
+            justify-content: flex-start;
+            &::before {
+                border-width: var(--border-width-more) 0 0 var(--border-width-more);
+                border-radius: var(--border-radius) 0 0 0;
+                left: calc(-0.5 * var(--profile-picture-size) - var(--gap-less));
+            }
         }
     }
 </style>

--- a/src/lib/components/messaging/message/Message.svelte
+++ b/src/lib/components/messaging/message/Message.svelte
@@ -81,6 +81,9 @@
             border-radius: var(--border-radius-more);
             border-bottom-left-radius: var(--border-radius-minimal);
             align-self: flex-start;
+            &.reply {
+                background-color: color-mix(in srgb, var(--alt-color) 50%, transparent);
+            }
         }
 
         &.highlight-success {
@@ -135,6 +138,7 @@
             font-size: var(--font-size-smaller);
             border-radius: var(--border-radius-more) !important;
             padding: var(--padding-less);
+            background-color: color-mix(in srgb, var(--primary-color) 50%, transparent);
 
             &.position-local {
                 align-self: flex-end;

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -687,6 +687,17 @@
                 {#if conversation}
                     {#each $conversation.messages as group}
                         <StoreResolver value={group.details.origin} resolver={v => Store.getUser(v)} let:resolved>
+                            {#if group.messages[0].inReplyTo}
+                                <StoreResolver value={group.messages[0].inReplyTo.details.origin} resolver={v => Store.getUser(v)} let:resolved>
+                                    <MessageReplyContainer first remote={group.messages[0].details.remote} image={resolved.profile.photo.image}>
+                                        <Message reply remote={group.messages[0].details.remote}>
+                                            {#each group.messages[0].inReplyTo.text as line}
+                                                <Text markdown={line} muted size={Size.Small} />
+                                            {/each}
+                                        </Message>
+                                    </MessageReplyContainer>
+                                </StoreResolver>
+                            {/if}
                             <MessageGroup
                                 profilePictureRequirements={{
                                     notifications: 0,
@@ -703,10 +714,10 @@
                                 username={resolved.name}
                                 subtext={getTimeAgo(group.messages[0].details.at)}>
                                 {#each group.messages as message, idx}
-                                    {#if message.inReplyTo}
+                                    {#if message.inReplyTo && idx !== 0}
                                         <StoreResolver value={message.inReplyTo.details.origin} resolver={v => Store.getUser(v)} let:resolved>
-                                            <MessageReplyContainer remote={message.inReplyTo.details.remote} image={resolved.profile.photo.image}>
-                                                <Message reply remote={message.inReplyTo.details.remote}>
+                                            <MessageReplyContainer remote={message.details.remote} image={resolved.profile.photo.image}>
+                                                <Message reply remote={message.details.remote}>
                                                     {#each message.inReplyTo.text as line}
                                                         <Text markdown={line} muted size={Size.Small} />
                                                     {/each}

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -690,7 +690,7 @@
                             {#if group.messages[0].inReplyTo}
                                 <StoreResolver value={group.messages[0].inReplyTo.details.origin} resolver={v => Store.getUser(v)} let:resolved>
                                     <MessageReplyContainer first remote={group.messages[0].details.remote} image={resolved.profile.photo.image}>
-                                        <Message reply remote={group.messages[0].details.remote}>
+                                        <Message reply remote={group.messages[0].inReplyTo.details.remote}>
                                             {#each group.messages[0].inReplyTo.text as line}
                                                 <Text markdown={line} muted size={Size.Small} />
                                             {/each}


### PR DESCRIPTION
### What this PR does 📖

- Redo reply ui:
  - Replied message is a bit darker
  - Fix reply message sender profile not always being on the right side
  - Message group profile pic is shifted down a bit to be next to the actual message instead of the reply message
  - Add an indicator above profile pic pointing to the reply if its the first message in the group

<img width="277" alt="Screenshot 2024-10-18 at 15 49 14" src="https://github.com/user-attachments/assets/7e9f748c-917d-415c-883a-b3387b9c2df1">


### Which issue(s) this PR fixes 🔨

- Resolve #722