### PR TITLE
feat(Call): Add username when user does not have video

### DIFF
--- a/src/lib/components/calling/Participant.svelte
+++ b/src/lib/components/calling/Participant.svelte
@@ -73,6 +73,7 @@
                 size={Size.Larger}
                 noIndicator
                 highlight={isMuted || isDeafened ? Appearance.Error : isTalking ? Appearance.Success : Appearance.Alt} />
+            <div class="user-name">{participant.name}</div>
         </div>
     {/if}
 </div>
@@ -82,6 +83,23 @@
         width: fit-content;
         height: fit-content;
         position: relative;
+
+        .simple {
+            display: flex; /* Alinha a imagem e o nome lado a lado */
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            &:hover {
+                cursor: pointer;
+            }
+        }
+
+        .user-name {
+            color: white;
+            padding-top: 8px;
+            font-size: 14px;
+            text-align: center; /* Alinha o texto no centro */
+        }
 
         video {
             width: 300px;
@@ -118,14 +136,6 @@
                 border-radius: var(--border-radius-less);
                 backdrop-filter: blur(var(--blur-radius));
                 -webkit-backdrop-filter: blur(var(--blur-radius));
-            }
-        }
-
-        .simple {
-            border-radius: 50%;
-            position: relative;
-            &:hover {
-                cursor: pointer;
             }
         }
 

--- a/src/lib/components/calling/Participant.svelte
+++ b/src/lib/components/calling/Participant.svelte
@@ -85,7 +85,7 @@
         position: relative;
 
         .simple {
-            display: flex; /* Alinha a imagem e o nome lado a lado */
+            display: flex;
             flex-direction: column;
             justify-content: center;
             align-items: center;
@@ -98,7 +98,7 @@
             color: white;
             padding-top: 8px;
             font-size: 14px;
-            text-align: center; /* Alinha o texto no centro */
+            text-align: center;
         }
 
         video {

--- a/src/lib/components/calling/Participant.svelte
+++ b/src/lib/components/calling/Participant.svelte
@@ -7,6 +7,7 @@
     import { mock_users } from "$lib/mock/users"
     import Controls from "$lib/layouts/Controls.svelte"
     import { Icon, Button, Text } from "$lib/elements"
+    import Spacer from "$lib/elements/Spacer.svelte"
 
     export let participant: User = defaultUser
     export let hasVideo: boolean = false
@@ -73,7 +74,8 @@
                 size={Size.Larger}
                 noIndicator
                 highlight={isMuted || isDeafened ? Appearance.Error : isTalking ? Appearance.Success : Appearance.Alt} />
-            <div class="user-name">{participant.name}</div>
+            <Spacer less />
+            <Text singleLine size={Size.Smaller}>{participant.name}</Text>
         </div>
     {/if}
 </div>
@@ -92,13 +94,6 @@
             &:hover {
                 cursor: pointer;
             }
-        }
-
-        .user-name {
-            color: white;
-            padding-top: 8px;
-            font-size: 14px;
-            text-align: center;
         }
 
         video {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Show username underneath user who is not using video feed
<img width="298" alt="image" src="https://github.com/user-attachments/assets/6827c458-a768-4bc5-a8fe-61eab6ffb513">


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
