### PR TITLE
fix(Call): Avoid incoming call from the same call if it is running

### DIFF
--- a/src/lib/components/calling/CallControls.svelte
+++ b/src/lib/components/calling/CallControls.svelte
@@ -9,7 +9,6 @@
     import { Store } from "$lib/state/Store"
 
     export let loading: boolean = false
-    export let duration: Date = get(Store.state.activeCall)?.startedAt || new Date()
     export let muted: boolean = get(Store.state.devices.muted)
     export let deafened: boolean = get(Store.state.devices.deafened)
     export let settings: ISettingsState = get(SettingsStore.state)
@@ -19,7 +18,7 @@
 
     function updateElapsedTime() {
         const now = new Date()
-        const diff = now.getTime() - new Date(duration).getTime()
+        const diff = now.getTime() - ($timeCallStarted ?? now).getTime()
 
         const hours = Math.floor(diff / (1000 * 60 * 60))
             .toString()
@@ -39,7 +38,7 @@
     // Cleanup interval on destroy
     import { onDestroy } from "svelte"
     import { goto } from "$app/navigation"
-    import { VoiceRTCInstance } from "$lib/media/Voice"
+    import { timeCallStarted, VoiceRTCInstance } from "$lib/media/Voice"
     onDestroy(() => {
         clearInterval(interval)
     })

--- a/src/lib/components/calling/CallScreen.svelte
+++ b/src/lib/components/calling/CallScreen.svelte
@@ -13,7 +13,7 @@
     import type { Chat } from "$lib/types"
     import VolumeMixer from "./VolumeMixer.svelte"
     import { createEventDispatcher, onDestroy, onMount } from "svelte"
-    import { callTimeout, TIME_TO_SHOW_CONNECTING, TIME_TO_SHOW_END_CALL_FEEDBACK, timeCallStarted, usersAcceptedTheCall, usersDeniedTheCall, VoiceRTCInstance } from "$lib/media/Voice"
+    import { callInProgress, callTimeout, TIME_TO_SHOW_CONNECTING, TIME_TO_SHOW_END_CALL_FEEDBACK, timeCallStarted, usersAcceptedTheCall, usersDeniedTheCall, VoiceRTCInstance } from "$lib/media/Voice"
     import { log } from "$lib/utils/Logger"
     import { playSound, SoundHandler, Sounds } from "../utils/SoundHandler"
 
@@ -152,7 +152,7 @@
         await VoiceRTCInstance.setVideoElements(localVideoCurrentSrc)
         /// HACK: To make sure the video elements are loaded before we start the call
         if (VoiceRTCInstance.localVideoCurrentSrc && VoiceRTCInstance.remoteVideoCreator) {
-            if (VoiceRTCInstance.toCall && VoiceRTCInstance.toCall.find(did => did !== "") !== undefined) {
+            if (VoiceRTCInstance.toCall && VoiceRTCInstance.toCall.find(did => did !== "") !== undefined && $callInProgress === null) {
                 callSound = await playSound(Sounds.OutgoingCall)
                 await VoiceRTCInstance.makeCall()
                 timeout = setTimeout(() => {

--- a/src/lib/components/calling/IncomingCall.svelte
+++ b/src/lib/components/calling/IncomingCall.svelte
@@ -6,7 +6,7 @@
     import ProfilePicture from "../profile/ProfilePicture.svelte"
     import { playSound, SoundHandler, Sounds } from "../utils/SoundHandler"
     import { Store } from "$lib/state/Store"
-    import { connectionOpened, VoiceRTCInstance } from "$lib/media/Voice"
+    import { callInProgress, connectionOpened, VoiceRTCInstance } from "$lib/media/Voice"
     import { goto } from "$app/navigation"
     import { writable } from "svelte/store"
     import { onDestroy, onMount } from "svelte"
@@ -77,7 +77,7 @@
     }
 </script>
 
-{#if pending}
+{#if pending && (VoiceRTCInstance.incomingCallFrom === null || (VoiceRTCInstance.incomingCallFrom && $callInProgress !== VoiceRTCInstance.incomingCallFrom[1]?.metadata.channel))}
     <div id="incoming-call">
         <div class="body">
             <div class="content" style={cancelledCall ? "border: var(--border-width) solid var(--warning-color);" : "border: var(--border-width) solid var(--success-color);"}>

--- a/src/lib/components/messaging/ChatPreview.svelte
+++ b/src/lib/components/messaging/ChatPreview.svelte
@@ -136,15 +136,13 @@
                 {chatName}
             </Text>
             <div class="right">
-                {#if $callInProgress === chat.id}
-                    <Button appearance={Appearance.Success} text={elapsedTime} small={true} on:click={_ => {}}>
-                        <Icon icon={Shape.PhoneCall} />
-                    </Button>
-                {:else}
-                    <Text hook="chat-preview-timestamp" class="timestamp min-text" loading={loading} size={Size.Smallest} muted>
+                <Text hook="chat-preview-timestamp" class="timestamp min-text" loading={loading} size={Size.Smallest} muted>
+                    {#if $callInProgress === chat.id}
+                        <Icon icon={Shape.PhoneCall} highlight={Appearance.Success} />
+                    {:else}
                         {timeago}
-                    </Text>
-                {/if}
+                    {/if}
+                </Text>
                 {#if !loading}
                     {#if chat.notifications > 0 && !$simpleUnreads}
                         <span class="unreads">
@@ -157,7 +155,6 @@
             </div>
         </div>
         <p class="last-message">
-            <Spacer less={true} />
             {#if loading}
                 <Loader text small />
                 <Loader text small />

--- a/src/lib/lang/en.json
+++ b/src/lib/lang/en.json
@@ -342,6 +342,7 @@
             "startCallMessage": "📞 A call started at {value}.",
             "endCallMessage": "📴 The call ended at {formattedEndTime}. Duration: {duration}.",
             "callMissed": "📞 Missed call",
+            "finishCurrentCallBeforeStartingAnother": "Finish current call before starting another",
             "voice": "Voice",
             "video": "Video",
             "decline": "Decline",

--- a/src/lib/media/Voice.ts
+++ b/src/lib/media/Voice.ts
@@ -21,6 +21,7 @@ export const usersDeniedTheCall: Writable<string[]> = writable([])
 export const usersAcceptedTheCall: Writable<string[]> = writable([])
 export const connectionOpened = writable(false)
 export const timeCallStarted: Writable<Date | null> = writable(null)
+export const callInProgress: Writable<string | null> = writable(null)
 
 export enum VoiceRTCMessageType {
     UpdateUser = "UPDATE_USER",
@@ -468,6 +469,7 @@ export class VoiceRTC {
                 }
             }, TIME_TO_WAIT_FOR_ANSWER)
             timeOuts.push(timeoutWhenCallIsNull)
+            callInProgress.set(this.channel!)
             Store.setActiveCall(Store.getCallingChat(this.channel!)!, CallDirection.Outbound)
         } catch (error) {
             log.error(`Error making call: ${error}`)
@@ -588,6 +590,7 @@ export class VoiceRTC {
         this.call?.room.leave()
         this.call = null
         this.channel = this.incomingCallFrom[0]
+        callInProgress.set(this.channel!)
         // Tell the other end you accepted the call
         this.incomingCallFrom[1].send(CALL_ACK)
         this.createAndSetRoom()
@@ -603,6 +606,7 @@ export class VoiceRTC {
     }
 
     async leaveCall(sendEndCallMessage = false) {
+        callInProgress.set(null)
         usersDeniedTheCall.set([])
         callTimeout.set(false)
         connectionOpened.set(false)

--- a/src/lib/media/Voice.ts
+++ b/src/lib/media/Voice.ts
@@ -609,6 +609,7 @@ export class VoiceRTC {
 
     async leaveCall(sendEndCallMessage = false) {
         callInProgress.set(null)
+        timeCallStarted.set(null)
         usersDeniedTheCall.set([])
         callTimeout.set(false)
         connectionOpened.set(false)

--- a/src/lib/media/Voice.ts
+++ b/src/lib/media/Voice.ts
@@ -504,17 +504,19 @@ export class VoiceRTC {
         while (!handled && !accepted && attempts < maxRetries) {
             try {
                 if (!conn) {
+                    let callStartedDate = new Date()
                     log.debug(`Trying to send invitation send out to ${peer} ${conn}`)
                     conn = this.localPeer!.connect(peer, {
                         metadata: {
                             did: get(Store.state.user).key,
                             username: get(Store.state.user).name,
                             channel: this.channel,
-                            timeCallStarted: new Date().toISOString(),
+                            timeCallStarted: callStartedDate.toISOString(),
                         },
                     })
                     conn.on("open", () => {
                         connected = true
+                        timeCallStarted.set(callStartedDate)
                     })
                     conn.once("data", d => {
                         if (d === CALL_ACK) {

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -1,31 +1,15 @@
 <script lang="ts">
-    import { callInProgress, VoiceRTCInstance, VoiceRTCMessageType } from "../../lib/media/Voice"
+    import { callInProgress, VoiceRTCInstance } from "../../lib/media/Voice"
     import { Appearance, ChatType, MessageAttachmentKind, MessagePosition, Route, Shape, Size, TooltipPosition } from "$lib/enums"
-    import { _, date, time } from "svelte-i18n"
+    import { _ } from "svelte-i18n"
     import { animationDuration } from "$lib/globals/animations"
     import { slide } from "svelte/transition"
     import { Chatbar, Sidebar, Topbar, Profile } from "$lib/layouts"
-    import {
-        FileEmbed,
-        ImageEmbed,
-        ChatPreview,
-        Conversation,
-        Message,
-        MessageGroup,
-        MessageReactions,
-        MessageReplyContainer,
-        ProfilePicture,
-        Modal,
-        ProfilePictureMany,
-        STLViewer,
-        ChatFilter,
-        ContextMenu,
-        EmojiGroup,
-    } from "$lib/components"
+    import { ImageEmbed, ChatPreview, Conversation, Message, MessageGroup, MessageReactions, MessageReplyContainer, ProfilePicture, Modal, ProfilePictureMany, ChatFilter, ContextMenu, EmojiGroup } from "$lib/components"
     import CreateTransaction from "$lib/components/wallet/CreateTransaction.svelte"
     import { Button, FileInput, Icon, Label, Text } from "$lib/elements"
     import CallScreen from "$lib/components/calling/CallScreen.svelte"
-    import { OperationState, type MessageGroup as MessageGroupType } from "$lib/types"
+    import { type MessageGroup as MessageGroupType } from "$lib/types"
     import EncryptedNotice from "$lib/components/messaging/EncryptedNotice.svelte"
     import { Store } from "$lib/state/Store"
     import { derived, get } from "svelte/store"
@@ -35,8 +19,6 @@
     import { ConversationStore, type ConversationMessages } from "$lib/state/conversation"
     import GroupSettings from "$lib/components/group/GroupSettings.svelte"
     import ViewMembers from "$lib/components/group/ViewMembers.svelte"
-    import AudioEmbed from "$lib/components/messaging/embeds/AudioEmbed.svelte"
-    import VideoEmbed from "$lib/components/messaging/embeds/VideoEmbed.svelte"
     import Market from "$lib/components/market/Market.svelte"
     import { RaygunStoreInstance } from "$lib/wasm/RaygunStore"
     import type { Attachment, FileInfo, Message as MessageType, User } from "$lib/types"
@@ -44,7 +26,6 @@
     import PendingMessage from "$lib/components/messaging/message/PendingMessage.svelte"
     import PendingMessageGroup from "$lib/components/messaging/PendingMessageGroup.svelte"
     import FileUploadPreview from "$lib/elements/FileUploadPreview.svelte"
-    import TextDocument from "$lib/components/messaging/embeds/TextDocument.svelte"
     import StoreResolver from "$lib/components/utils/StoreResolver.svelte"
     import { getValidPaymentRequest } from "$lib/utils/Wallet"
     import { onMount } from "svelte"
@@ -57,7 +38,7 @@
     import BrowseFiles from "../files/BrowseFiles.svelte"
     import AttachmentRenderer from "$lib/components/messaging/AttachmentRenderer.svelte"
     import ShareFile from "$lib/components/files/ShareFile.svelte"
-    import { log } from "$lib/utils/Logger"
+    import { ToastMessage } from "$lib/state/ui/toast"
 
     let loading = false
     let contentAsideOpen = false
@@ -376,6 +357,10 @@
         )
     }
 
+    function notificationThereIsACallInProgress() {
+        Store.addToastNotification(new ToastMessage("", $_("settings.calling.finishCurrentCallBeforeStartingAnother"), 4))
+    }
+
     document.addEventListener("click", handleClickOutsideEditInput)
 </script>
 
@@ -584,7 +569,7 @@
                         disabled={$activeChat.users.length === 0}
                         on:click={async _ => {
                             if ($callInProgress !== null) {
-                                log.warn("You need to leave your current call first before starting a new one")
+                                notificationThereIsACallInProgress()
                                 return
                             } else {
                                 Store.setActiveCall($activeChat)
@@ -604,7 +589,7 @@
                         loading={loading}
                         on:click={async _ => {
                             if ($callInProgress !== null) {
-                                log.warn("You need to leave your current call first before starting a new one")
+                                notificationThereIsACallInProgress()
                                 return
                             } else {
                                 await VoiceRTCInstance.startToMakeACall($activeChat.users, $activeChat.id)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- When you are in call, you are not receiving incoming from the same call, just if other call chat starts. 

- Fixed timestamp on controls (Now you can go to other pages and back, it will calculate again correct call time)
<img width="175" alt="image" src="https://github.com/user-attachments/assets/d20d5ce7-abf8-4d9c-948b-9e879f0c23b1">


- Added indicator that there is a call in progress for that specific chat
<img width="171" alt="image" src="https://github.com/user-attachments/assets/72456891-c1f4-45d7-8607-8714cad6e359">

- If you are in a call, app will block you to do new calls before finish current one, and you will receive a notification
<img width="473" alt="image" src="https://github.com/user-attachments/assets/868041b1-49d3-4a64-9e79-bbc5a6abf72d">


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
