### PR TITLE
update(ci): increase retention days for test artifacts

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -58,7 +58,7 @@ jobs:
               with:
                   name: playwright-report-${{ matrix.project }}
                   path: automated-tests/blob-report/
-                  retention-days: 1
+                  retention-days: 5
 
             - name: Upload Allure results as artifact
               if: always()
@@ -66,7 +66,7 @@ jobs:
               with:
                   name: allure-results-${{ matrix.project }}
                   path: automated-tests/allure-results
-                  retention-days: 1
+                  retention-days: 5
 
             - name: Add label if any of build jobs failed
               if: failure()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Sometimes CI test jobs cannot be retried because the artifacts are already expired (example publishing reports will fail if artifacts have been already purged). Currently the retention days for test artifacts is just one day, so we are increasing to 5 days, so we dont have issues when retrying jobs

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
