### PR TITLE
fix(call): retry connection instead of wait if not made

### DIFF
--- a/src/lib/media/Voice.ts
+++ b/src/lib/media/Voice.ts
@@ -549,12 +549,14 @@ export class VoiceRTC {
                         }
                     })
                 }
-                await new Promise(resolve => timeOuts.push(setTimeout(resolve, 5000)))
+                await new Promise(resolve => timeOuts.push(setTimeout(resolve, 3000)))
                 if (connected) {
                     // If connection has been made let it ring for 30 sec.
                     await new Promise(resolve => timeOuts.push(setTimeout(resolve, 30000)))
                     conn.close()
                     break
+                } else {
+                    conn = undefined
                 }
             } catch (error) {
                 attempts += 1


### PR DESCRIPTION
### What this PR does 📖

- Retry call invitation connection instead of just waiting. Also reduce retry wait time

### Which issue(s) this PR fixes 🔨

- Potentially?: Feedback for no response, and when people joined the call maybe is not correct when we have a lot of people in the call (BUG)
