### PR TITLE
update(ci): use two jobs for publishing reports

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -124,8 +124,7 @@ jobs:
             contents: write
             issues: read
         concurrency:
-            group: deploy-gh-pages-${{ github.ref }}
-            cancel-in-progress: true
+            group: ${{ github.workflow }}-${{ github.ref }}
         steps:
             - uses: actions/checkout@v4.2.2
               with:
@@ -144,7 +143,7 @@ jobs:
               run: echo "timestamp=$(date --utc +%Y%m%d_%H%M%SZ)" >> "$GITHUB_OUTPUT"
 
             - name: Deploy Playwright HTML report to Github Pages
-              if: success()
+              if: github.ref == 'refs/heads/main'
               uses: peaceiris/actions-gh-pages@v4
               with:
                   deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -173,8 +172,7 @@ jobs:
             contents: write
             issues: read
         concurrency:
-            group: deploy-gh-pages-${{ github.ref }}
-            cancel-in-progress: true
+            group: ${{ github.workflow }}-${{ github.ref }}
         steps:
             - name: Download Allure results artifact for desktop
               uses: actions/download-artifact@v4.1.8
@@ -216,8 +214,8 @@ jobs:
                   github_repo_owner: Satellite-im
 
             - name: Deploy report to Github Pages
-              if: success()
               uses: peaceiris/actions-gh-pages@v4
+              if: github.ref == 'refs/heads/main'
               with:
                   deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
                   external_repository: Satellite-im/test-reports

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -160,7 +160,6 @@ jobs:
               run: echo "playwright_report_url=https://satellite-im.github.io/test-reports/${{ steps.timestampidone.outputs.timestamp }}/" >> "$GITHUB_OUTPUT"
 
     publish-allure-report:
-        if: always()
         needs: publish-playwright-report
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -114,7 +114,7 @@ jobs:
                       playwright-report-desktop-chrome
                       playwright-report-mobile-chrome
 
-    publish-report:
+    publish-playwright-report:
         if: always()
         needs: merge-reports
         runs-on: ubuntu-latest
@@ -131,6 +131,7 @@ jobs:
               with:
                   repository: Satellite-im/test-reports
                   ref: gh-pages
+                  path: gh-pages
 
             - name: Download Merged Report
               uses: actions/download-artifact@v4
@@ -153,14 +154,28 @@ jobs:
                   publish_dir: ./playwright-report
                   destination_dir: ${{ steps.timestampidone.outputs.timestamp }}
 
-            - name: Stop ssh-agent job from first deploy required for deploying a second time
-              run: killall ssh-agent
-
-            - uses: actions/checkout@v4.2.2
+            - name: Comment PR with Playwright test results
+              if: always() && github.event_name == 'pull_request'
+              uses: mshick/add-pr-comment@v2.8.2
               with:
-                  repository: Satellite-im/test-reports
-                  ref: gh-pages
+                  message: |
+                      Automated tests execution is complete! You can find the Playwright test report [here](https://satellite-im.github.io/test-reports/${{ steps.timestampidone.outputs.timestamp }}/)
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    publish-allure-report:
+        if: always()
+        needs: publish-playwright-report
+        runs-on: ubuntu-latest
+        permissions:
+            checks: write
+            pull-requests: write
+            contents: write
+            issues: read
+        concurrency:
+            group: deploy-gh-pages-${{ github.ref }}
+            cancel-in-progress: true
+        steps:
             - name: Download Allure results artifact for desktop
               uses: actions/download-artifact@v4.1.8
               with:
@@ -188,9 +203,6 @@ jobs:
                   ref: gh-pages
                   path: gh-pages
 
-            - name: Pull changes from gh-pages
-              run: git pull --rebase origin gh-pages
-
             - name: Generate Allure Report
               if: always()
               uses: simple-elf/allure-report-action@master
@@ -199,16 +211,9 @@ jobs:
                   allure_results: allure-results
                   allure_report: allure-report
                   allure_history: allure-history
-                  keep_reports: 100
+                  keep_reports: 20
                   github_repo: Satellite-im/test-reports
                   github_repo_owner: Satellite-im
-
-            - name: Set a timestamp two
-              id: timestampidtwo
-              run: echo "timestamp=$(date --utc +%Y%m%d_%H%M%SZ)" >> "$GITHUB_OUTPUT"
-
-            - name: Pull changes from gh-pages
-              run: git pull --rebase origin gh-pages
 
             - name: Deploy report to Github Pages
               if: success()
@@ -224,12 +229,12 @@ jobs:
               uses: mshick/add-pr-comment@v2.8.2
               with:
                   message: |
-                      Automated tests execution is complete! You can find the Playwright test report [here](https://satellite-im.github.io/test-reports/${{ steps.timestampidone.outputs.timestamp }}/) and the Allure Test Report [here](https://satellite-im.github.io/test-reports/${{ github.run_number }})
+                      Automated tests execution is complete! You can find the Allure Test Report [here](https://satellite-im.github.io/test-reports/${{ github.run_number }})
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     remove-label:
-        needs: [playwright-run, merge-reports, publish-report]
+        needs: [playwright-run, merge-reports, publish-playwright-report, publish-allure-report]
         runs-on: ubuntu-latest
         permissions:
             checks: write

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -145,12 +145,11 @@ jobs:
               run: echo "timestamp=$(date --utc +%Y%m%d_%H%M%SZ)" >> "$GITHUB_OUTPUT"
 
             - name: Deploy Playwright HTML report to Github Pages
-              if: github.ref == 'refs/heads/main'
+              if: always()
               uses: peaceiris/actions-gh-pages@v4
               with:
                   deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
                   external_repository: Satellite-im/test-reports
-                  keep_files: true
                   publish_branch: gh-pages
                   publish_dir: ./playwright-report
                   destination_dir: ${{ steps.timestampidone.outputs.timestamp }}
@@ -211,7 +210,7 @@ jobs:
 
             - name: Deploy report to Github Pages
               uses: peaceiris/actions-gh-pages@v4
-              if: github.ref == 'refs/heads/main'
+              if: always()
               with:
                   deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
                   external_repository: Satellite-im/test-reports

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -125,6 +125,8 @@ jobs:
             issues: read
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref }}
+        outputs:
+            playwright_report_url: ${{ steps.comment.outputs.playwright_report_url }}
         steps:
             - uses: actions/checkout@v4.2.2
               with:
@@ -153,14 +155,9 @@ jobs:
                   publish_dir: ./playwright-report
                   destination_dir: ${{ steps.timestampidone.outputs.timestamp }}
 
-            - name: Comment PR with Playwright test results
-              if: always() && github.event_name == 'pull_request'
-              uses: mshick/add-pr-comment@v2.8.2
-              with:
-                  message: |
-                      Automated tests execution is complete! You can find the Playwright test report [here](https://satellite-im.github.io/test-reports/${{ steps.timestampidone.outputs.timestamp }}/)
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Set Playwright report URL output
+              id: comment
+              run: echo "playwright_report_url=https://satellite-im.github.io/test-reports/${{ steps.timestampidone.outputs.timestamp }}/" >> "$GITHUB_OUTPUT"
 
     publish-allure-report:
         if: always()
@@ -227,7 +224,7 @@ jobs:
               uses: mshick/add-pr-comment@v2.8.2
               with:
                   message: |
-                      Automated tests execution is complete! You can find the Allure Test Report [here](https://satellite-im.github.io/test-reports/${{ github.run_number }})
+                      Automated tests execution is complete! You can find the Playwright test report [here](${{ needs.publish-playwright-report.outputs.playwright_report_url }}) and the Allure Test Report [here](https://satellite-im.github.io/test-reports/${{ github.run_number }})
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Reducing number of reports kept by Allure
- Changes to publish report (using two jobs, one for playwright and one for allure)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
