### PR TITLE
refactor(calling): update call screen component

### DIFF
--- a/src/lib/media/Voice.ts
+++ b/src/lib/media/Voice.ts
@@ -1,4 +1,4 @@
-import { playSound, Sounds } from "$lib/components/utils/SoundHandler"
+import { playSound, SoundHandler, Sounds } from "$lib/components/utils/SoundHandler"
 import { CallDirection } from "$lib/enums"
 import { Store } from "$lib/state/Store"
 import { create_cancellable_handler, type Cancellable } from "$lib/utils/CancellablePromise"
@@ -23,6 +23,7 @@ export const usersAcceptedTheCall: Writable<string[]> = writable([])
 export const connectionOpened = writable(false)
 export const timeCallStarted: Writable<Date | null> = writable(null)
 export const callInProgress: Writable<string | null> = writable(null)
+export const makeCallSound = writable<SoundHandler | undefined>(undefined)
 
 export enum VoiceRTCMessageType {
     UpdateUser = "UPDATE_USER",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- This commit refactors the CallScreen component in the calling feature. It updates the import statements for the VoiceRTCInstance and makeCallSound variables. It also adds a new function stopMakeCallSound() to stop the make call sound. Additionally, it removes the callSound variable and replaces it with the makeCallSound variable. The commit also includes some code cleanup and formatting changes.


https://github.com/user-attachments/assets/a3e6fb85-9d76-4493-ad7a-ae0d08af6131



### Which issue(s) this PR fixes 🔨

- Resolve #818 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
