### PR TITLE
feat(profile): add PIN confirmation for account deletion and enhance settings UI

### DIFF
--- a/src/lib/components/PinInput.svelte
+++ b/src/lib/components/PinInput.svelte
@@ -10,6 +10,7 @@
     export let scramble: boolean = false
     export let stayLoggedIn: boolean = true
     export let showSettings: boolean = false
+    export let showButtonSettings: boolean = true
     export let min: number = 4
     export let max: number = 6
 
@@ -156,28 +157,30 @@
         </div>
     {/key}
     <Spacer less />
-    <div class="flex-column">
-        <Button
-            outline={!showSettings}
-            hook="button-settings"
-            appearance={Appearance.Alt}
-            on:click={_ => {
-                showSettings = !showSettings
-            }}>
-            <Icon icon={showSettings ? Shape.ChevronDown : Shape.ChevronRight} /> Settings
-        </Button>
-        <div class="pin-settings flex-column {showSettings ? 'visible' : 'hidden'}">
-            <div class="flex-row setting">
-                <Switch hook="switch-scramble-keypad" on={scramble} on:toggle={handleToggleScramble} />
-                <Label text={$_("pages.auth.unlock.scramble_pin")} hook="label-scramble-keypad" />
-            </div>
-            <hr class="divider" />
-            <div class="flex-row setting">
-                <Switch hook="switch-stay-unlocked" on={stayLoggedIn} on:toggle={handleStayLoggedIn} />
-                <Label text={$_("pages.auth.unlock.stayUnlocked")} hook="label-stay-unlocked" />
+    {#if showButtonSettings}
+        <div class="flex-column">
+            <Button
+                outline={!showSettings}
+                hook="button-settings"
+                appearance={Appearance.Alt}
+                on:click={_ => {
+                    showSettings = !showSettings
+                }}>
+                <Icon icon={showSettings ? Shape.ChevronDown : Shape.ChevronRight} /> Settings
+            </Button>
+            <div class="pin-settings flex-column {showSettings ? 'visible' : 'hidden'}">
+                <div class="flex-row setting">
+                    <Switch hook="switch-scramble-keypad" on={scramble} on:toggle={handleToggleScramble} />
+                    <Label text={$_("pages.auth.unlock.scramble_pin")} hook="label-scramble-keypad" />
+                </div>
+                <hr class="divider" />
+                <div class="flex-row setting">
+                    <Switch hook="switch-stay-unlocked" on={stayLoggedIn} on:toggle={handleStayLoggedIn} />
+                    <Label text={$_("pages.auth.unlock.stayUnlocked")} hook="label-stay-unlocked" />
+                </div>
             </div>
         </div>
-    </div>
+    {/if}
 </div>
 
 <style lang="scss">

--- a/src/lib/lang/en.json
+++ b/src/lib/lang/en.json
@@ -330,6 +330,9 @@
             },
             "delete_title": "Delete Account",
             "delete_subtitle": "Click here to delete your account",
+            "delete_account_action_description": "This action will delete your account permanently",
+            "delete_account_confirm_pin": "Enter your pin to confirm",
+            "delete_account_wrong_pin": "Incorrect PIN. Please try again to delete your account.",
             "change_profile_photo": "Change profile photo",
             "reveal_phrase": {
                 "label": "Reveal recovery phrase",

--- a/src/lib/layouts/login/Unlock.svelte
+++ b/src/lib/layouts/login/Unlock.svelte
@@ -25,13 +25,13 @@
     let showConfigureRelay = false
 
     // Function to delete IndexedDB database by name
-    function deleteIndexedDB(dbName) {
+    function deleteIndexedDB(dbName: string) {
         return new Promise((resolve, reject) => {
             const request = indexedDB.deleteDatabase(dbName)
 
             request.onsuccess = function () {
                 console.log(`Database '${dbName}' deleted successfully.`)
-                resolve()
+                resolve("Success")
             }
 
             request.onerror = function () {

--- a/src/lib/layouts/login/Unlock.svelte
+++ b/src/lib/layouts/login/Unlock.svelte
@@ -158,7 +158,11 @@
                 appearance={Appearance.Alt}
                 icon
                 on:click={_ => {
-                    isDeleteAccountModalOpened.set(true)
+                    if (get(AuthStore.state).pin === "") {
+                        clearAllData()
+                    } else {
+                        isDeleteAccountModalOpened.set(true)
+                    }
                 }}>
                 <Icon icon={Shape.Trash} />
             </Button>

--- a/src/routes/settings/profile/+page.svelte
+++ b/src/routes/settings/profile/+page.svelte
@@ -665,8 +665,12 @@
                 isDeleteAccountModalOpened.set(false)
             }}>
             <div class="delete-account-pin">
-                <Label text={$_("settings.profile.delete_account_action_description")} />
-                <Label text={$_("settings.profile.delete_account_confirm_pin")} />
+                <Text hook="text-delete-account-pin-first-message" class="delete-account-pin-first-message" appearance={Appearance.Error}>
+                    {$_("settings.profile.delete_account_action_description")}
+                </Text>
+                <Text>
+                    {$_("settings.profile.delete_account_confirm_pin")}
+                </Text>
                 <PinInput
                     min={4}
                     max={8}
@@ -865,7 +869,6 @@
             gap: var(--gap);
             align-items: center;
             padding: var(--padding);
-            width: var(--max-component-width);
         }
     }
 </style>

--- a/src/routes/settings/profile/+page.svelte
+++ b/src/routes/settings/profile/+page.svelte
@@ -22,6 +22,7 @@
     import { identityColor, toIntegrationIconSrc, toIntegrationKind } from "$lib/utils/ProfileUtils"
     import { log } from "$lib/utils/Logger"
     import Modal from "$lib/components/ui/Modal.svelte"
+    import PinInput from "$lib/components/PinInput.svelte"
 
     enum SeedState {
         Hidden,
@@ -33,6 +34,8 @@
     let isValidUsernameToUpdate = false
     let isValidStatusMessageToUpdate = true
     let seedPhrase = TesseractStoreInstance.fetchSeed()?.split(" ")
+    let isDeleteAccountModalOpened = writable(false)
+    let wrongPinToDeleteAccountMessage = $_("settings.profile.delete_account_wrong_pin")
 
     function toggleSeedPhrase() {
         if (showSeed === SeedState.Missing) return
@@ -101,13 +104,13 @@
     }
 
     // Function to delete IndexedDB database by name
-    function deleteIndexedDB(dbName) {
-        return new Promise((resolve, reject) => {
+    function deleteIndexedDB(dbName: string) {
+        return new Promise<string>((resolve, reject) => {
             const request = indexedDB.deleteDatabase(dbName)
 
             request.onsuccess = function () {
                 console.log(`Database '${dbName}' deleted successfully.`)
-                resolve()
+                resolve("Success")
             }
 
             request.onerror = function () {
@@ -646,15 +649,47 @@
         <SettingSection hook="section-delete-account" name={$_("settings.profile.delete_title")} description={$_("settings.profile.delete_subtitle")}>
             <Button
                 hook="button-delete-account"
-                appearance={Appearance.Alt}
+                appearance={Appearance.Error}
                 text={$_("settings.profile.delete_title")}
                 on:click={_ => {
-                    clearAllData()
+                    isDeleteAccountModalOpened.set(true)
+                    // clearAllData()
                 }}>
                 <Icon icon={Shape.Trash} />
             </Button>
         </SettingSection>
     </div>
+    {#if $isDeleteAccountModalOpened}
+        <Modal
+            on:close={_ => {
+                isDeleteAccountModalOpened.set(false)
+            }}>
+            <div class="delete-account-pin">
+                <Label text={$_("settings.profile.delete_account_action_description")} />
+                <Label text={$_("settings.profile.delete_account_confirm_pin")} />
+                <PinInput
+                    min={4}
+                    max={8}
+                    loading={false}
+                    scramble={false}
+                    stayLoggedIn={false}
+                    showSettings={false}
+                    showButtonSettings={false}
+                    on:submit={async e => {
+                        let pin = e.detail
+                        await new Promise(async _ => {
+                            let result = await TesseractStoreInstance.unlock(pin)
+                            result.onFailure(_ => {
+                                Store.addToastNotification(new ToastMessage("", wrongPinToDeleteAccountMessage, 3))
+                            })
+                            result.onSuccess(async _ => {
+                                await clearAllData()
+                            })
+                        })
+                    }} />
+            </div>
+        </Modal>
+    {/if}
 </div>
 
 <style lang="scss">
@@ -822,6 +857,15 @@
             align-items: center;
             gap: var(--gap);
             padding: var(--padding);
+        }
+
+        .delete-account-pin {
+            display: flex;
+            flex-direction: column;
+            gap: var(--gap);
+            align-items: center;
+            padding: var(--padding);
+            width: var(--max-component-width);
         }
     }
 </style>


### PR DESCRIPTION
### What this PR does 📖

#### 1. Change delete account button to red (Showing that is a dangerous action)

  <details><summary>Image</summary>
  <p>
  
 <img width="510" alt="image" src="https://github.com/user-attachments/assets/bcb0cfbe-b7c9-4a68-9e36-a535c92ae0f7">

  </p>
  </details> 


#### 2. Add modal when user click on delete account button on profile page

- If user type wrong pin, it will show a error toast message: 

    <details><summary>Video showing behavior</summary>
    <p>
    
    https://github.com/user-attachments/assets/0f4b4e56-ba84-4c92-a3f6-4402e1ddf564
    

    
    </p>
    </details> 

- If user type correct pin, it will delete account permanently:

    <details><summary>Video showing behavior</summary>
    <p>
    
    https://github.com/user-attachments/assets/b682d8e0-f06e-400b-8261-9e7cc62f4210
    
    </p>
    </details> 

### Which issue(s) this PR fixes 🔨

-   Resolve #848 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
