### PR TITLE
fix(calling): refactor code to avoid getTime from a null variable

### DIFF
--- a/src/lib/components/calling/CallScreen.svelte
+++ b/src/lib/components/calling/CallScreen.svelte
@@ -213,10 +213,11 @@
                 }, TIME_TO_SHOW_CONNECTING)
             }
         }
-        if ($timeCallStarted) {
+        let timeCallStarted = $timeCallStarted
+        if (timeCallStarted !== null) {
             let timeCallStartedInterval = setInterval(() => {
                 let now = new Date()
-                let timeDifference = now.getTime() - $timeCallStarted.getTime()
+                let timeDifference = now.getTime() - timeCallStarted.getTime()
                 if (timeDifference > TIME_TO_SHOW_CONNECTING) {
                     showAnimation = false
                     noResponseVisible = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

This pull request includes a minor change to the `CallScreen.svelte` file to improve the handling of the `timeCallStarted` variable. The change ensures that the variable is checked for `null` before being used.

* [`src/lib/components/calling/CallScreen.svelte`](diffhunk://#diff-7fb298436c145f100a88f4894f81ebbe77b50f1630c0907218b81ca5dbad840fL216-R220): Modified the code to assign `$timeCallStarted` to a local variable `timeCallStarted` and added a null check before using it.

### Which issue(s) this PR fixes 🔨

-   Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
