### PR TITLE
feat(Call): Enable screen share on calls.

### DIFF
--- a/src/lib/components/calling/CallScreen.svelte
+++ b/src/lib/components/calling/CallScreen.svelte
@@ -488,7 +488,7 @@
                                         <track kind="captions" src="" />
                                     </video>
                                     <div class="user-name">
-                                        {$remoteStreams[user].user.screenShareEnabled ? $userCache[user].name + " is sharing screen" : $userCache[user].name}
+                                        {$userCache[user].name}
                                     </div>
                                     {#if !$remoteStreams[user].user.audioEnabled}
                                         <div class="mute-status">

--- a/src/lib/components/calling/CallScreen.svelte
+++ b/src/lib/components/calling/CallScreen.svelte
@@ -241,6 +241,7 @@
         }
         if (get(Store.state.activeCall) === null) {
             Store.setActiveCall(chat)
+            Store.state.devices.screenShare.set(false)
         }
         window.addEventListener("resize", updateUserListSplit)
         updateUserListSplit()
@@ -265,6 +266,9 @@
             clearTimeout(hideNoResponseUsersTimeout)
         }
         stopMakeCallSound()
+        if (get(Store.state.activeCall) === null && get(Store.state.devices.screenShare) === true) {
+            Store.state.devices.screenShare.set(false)
+        }
     })
 
     function updateUserListSplit() {

--- a/src/lib/components/calling/CallScreen.svelte
+++ b/src/lib/components/calling/CallScreen.svelte
@@ -487,7 +487,9 @@
                                         use:attachStream={user}>
                                         <track kind="captions" src="" />
                                     </video>
-                                    <div class="user-name">{$userCache[user].name}</div>
+                                    <div class="user-name">
+                                        {$remoteStreams[user].user.screenShareEnabled ? $userCache[user].name + " is sharing screen" : $userCache[user].name}
+                                    </div>
                                     {#if !$remoteStreams[user].user.audioEnabled}
                                         <div class="mute-status">
                                             <Icon icon={Shape.MicrophoneSlash}></Icon>
@@ -597,7 +599,9 @@
                 icon
                 tooltip={$_("call.stream")}
                 on:click={async _ => {
-                    Store.updateScreenShareEnabled(!screenShareEnabled)
+                    // This component handles the call screen UI. In this specific case, the user has the option to cancel screen sharing.
+                    // The UI should not be updated until the user decides whether to share their screen or not.
+                    await VoiceRTCInstance.toggleScreenShare(!screenShareEnabled)
                 }}>
                 <Icon icon={Shape.Stream} />
             </Button>

--- a/src/lib/media/Voice.ts
+++ b/src/lib/media/Voice.ts
@@ -423,9 +423,11 @@ export class VoiceRTC {
 
     async toggleVideo(state: boolean) {
         this.callOptions.video.enabled = state
-        this.localStream?.getVideoTracks().forEach(track => (track.enabled = state))
+        if (!this.isScreenSharing) {
+            this.localStream?.getVideoTracks().forEach(track => (track.enabled = state))
+            this.call?.toggleStreams(state, ToggleType.Video)
+        }
 
-        this.call?.toggleStreams(state, ToggleType.Video)
         this.call?.notify(VoiceRTCMessageType.UpdateUser)
     }
 
@@ -550,6 +552,9 @@ export class VoiceRTC {
             this.screenStream.getTracks().forEach(track => track.stop())
             this.screenStream = null
             this.isScreenSharing = false
+            if (this.callOptions.video.enabled) {
+                Store.updateCameraEnabled(true)
+            }
             this.call?.notify(VoiceRTCMessageType.UpdateUser)
         }
     }

--- a/src/lib/media/Voice.ts
+++ b/src/lib/media/Voice.ts
@@ -529,7 +529,7 @@ export class VoiceRTC {
             }
             this.call?.notify(VoiceRTCMessageType.UpdateUser)
         } catch (err) {
-            Store.updateScreenShareEnabled(false)
+            Store.state.devices.screenShare.set(false)
             this.callOptions.video.screenShareEnabled = false
             log.error("Error starting screen share:", err)
         }
@@ -948,6 +948,7 @@ export class VoiceRTC {
         this.call?.room.leave()
         this.call = null
         Store.state.activeCallMeta.set({})
+        Store.state.devices.screenShare.set(false)
     }
 
     handleError(error: Error) {

--- a/src/lib/state/Store.ts
+++ b/src/lib/state/Store.ts
@@ -38,6 +38,7 @@ class GlobalStore {
                 output: createPersistentState("uplink.devices.output", "default"),
                 muted: createPersistentState("uplink.devices.muted", false),
                 deafened: createPersistentState("uplink.devices.deafened", false),
+                screenShare: createPersistentState("uplink.devices.screenShare", false),
             },
             friends: createPersistentState("uplink.friends", []),
             blocked: createPersistentState("uplink.blocked", []),
@@ -189,6 +190,11 @@ class GlobalStore {
 
     updateCameraEnabled(enabled: boolean) {
         this.state.devices.cameraEnabled.set(enabled)
+        if (get(SettingsStore.state).audio.controlSounds) playSound(enabled ? Sounds.Off : Sounds.On)
+    }
+
+    updateScreenShareEnabled(enabled: boolean) {
+        this.state.devices.screenShare.set(enabled)
         if (get(SettingsStore.state).audio.controlSounds) playSound(enabled ? Sounds.Off : Sounds.On)
     }
 

--- a/src/lib/state/Store.ts
+++ b/src/lib/state/Store.ts
@@ -38,7 +38,7 @@ class GlobalStore {
                 output: createPersistentState("uplink.devices.output", "default"),
                 muted: createPersistentState("uplink.devices.muted", false),
                 deafened: createPersistentState("uplink.devices.deafened", false),
-                screenShare: createPersistentState("uplink.devices.screenShare", false),
+                screenShare: writable(false),
             },
             friends: createPersistentState("uplink.friends", []),
             blocked: createPersistentState("uplink.blocked", []),

--- a/src/lib/state/initial.ts
+++ b/src/lib/state/initial.ts
@@ -18,6 +18,7 @@ export interface IState {
         output: Writable<string>
         cameraEnabled: Writable<boolean>
         video: Writable<string>
+        screenShare: Writable<boolean>
     }
     activeChat: Writable<Chat>
     chatMessagesToSend: Writable<{ [key: string]: string }>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

This pull request introduces the screen sharing feature in the calling component of the application. The changes include updates to the `CallScreen.svelte` file to handle screen sharing UI and state management, as well as modifications to the `Voice.ts` file to manage screen sharing logic.

Changes to `CallScreen.svelte`:

* Added a new state variable `screenShareEnabled` and subscribed to its changes from the store. [[1]](diffhunk://#diff-7fb298436c145f100a88f4894f81ebbe77b50f1630c0907218b81ca5dbad840fR33) [[2]](diffhunk://#diff-7fb298436c145f100a88f4894f81ebbe77b50f1630c0907218b81ca5dbad840fR131-R136)
* Updated the UI to conditionally display video elements based on the `screenShareEnabled` state. [[1]](diffhunk://#diff-7fb298436c145f100a88f4894f81ebbe77b50f1630c0907218b81ca5dbad840fL349-R368) [[2]](diffhunk://#diff-7fb298436c145f100a88f4894f81ebbe77b50f1630c0907218b81ca5dbad840fL360-R378) [[3]](diffhunk://#diff-7fb298436c145f100a88f4894f81ebbe77b50f1630c0907218b81ca5dbad840fL372-R399) [[4]](diffhunk://#diff-7fb298436c145f100a88f4894f81ebbe77b50f1630c0907218b81ca5dbad840fL404-R437) [[5]](diffhunk://#diff-7fb298436c145f100a88f4894f81ebbe77b50f1630c0907218b81ca5dbad840fL417-R447) [[6]](diffhunk://#diff-7fb298436c145f100a88f4894f81ebbe77b50f1630c0907218b81ca5dbad840fL448-R500)
* Modified the button appearance and functionality to toggle screen sharing.

Changes to `Voice.ts`:

* Added `screenShareEnabled` to the `VoiceRTCOptions` and `VoiceRTCUser` types. [[1]](diffhunk://#diff-a75896c18790a15b7e0ae422d555a80c3e09067296e47a5dcc6891ab3385dfb4R65-R67) [[2]](diffhunk://#diff-a75896c18790a15b7e0ae422d555a80c3e09067296e47a5dcc6891ab3385dfb4R78)
* Updated the `Participant` and `CallRoom` classes to include `screenShareEnabled`. [[1]](diffhunk://#diff-a75896c18790a15b7e0ae422d555a80c3e09067296e47a5dcc6891ab3385dfb4R182) [[2]](diffhunk://#diff-a75896c18790a15b7e0ae422d555a80c3e09067296e47a5dcc6891ab3385dfb4R325)
* Implemented screen sharing logic in the `VoiceRTC` class, including methods to start and stop screen sharing. [[1]](diffhunk://#diff-a75896c18790a15b7e0ae422d555a80c3e09067296e47a5dcc6891ab3385dfb4R361-R363) [[2]](diffhunk://#diff-a75896c18790a15b7e0ae422d555a80c3e09067296e47a5dcc6891ab3385dfb4R412-R426) [[3]](diffhunk://#diff-a75896c18790a15b7e0ae422d555a80c3e09067296e47a5dcc6891ab3385dfb4R507-R563) [[4]](diffhunk://#diff-a75896c18790a15b7e0ae422d555a80c3e09067296e47a5dcc6891ab3385dfb4R933-R937) [[5]](diffhunk://#diff-a75896c18790a15b7e0ae422d555a80c3e09067296e47a5dcc6891ab3385dfb4R962)

Changes to `Store.ts`:

* Added a new writable state `screenShare` to manage screen sharing state.
* Added a method `updateScreenShareEnabled` to update the screen sharing state.

Changes to `initial.ts`:

* Added `screenShare` to the `IState` interface.

> [!NOTE]
>  1. Screen share has more priority than camera enable, so when user share screen, his camera stream will be changed to share screen.
> 2. User can enable and disable camera during share screen, the result we can see after user disable share screen. 
> 3. User should be able to go out from chat, back to it, and keep share screen all the time.  

### Which issue(s) this PR fixes 🔨

-   Resolve #853 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
