### PR TITLE
update(desktop): fix download app banner showing in desktop versions

### DIFF
--- a/src/lib/components/ui/InstallBanner.svelte
+++ b/src/lib/components/ui/InstallBanner.svelte
@@ -31,7 +31,7 @@
     }
 
     function isTauri(): boolean {
-        return typeof window !== "undefined" && "__TAURI__" in window
+        return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window
     }
 
     function isCapacitor(): boolean {

--- a/src/lib/components/ui/InstallBanner.svelte
+++ b/src/lib/components/ui/InstallBanner.svelte
@@ -66,7 +66,7 @@
             icon: Shape.Android,
             download: DOWNLOAD_LINKS.Android,
         },
-          [Platform.iOS]: {
+        [Platform.iOS]: {
             text: "iPhone",
             icon: Shape.Apple,
             download: DOWNLOAD_LINKS.iOS,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Download banner was showing on desktop builds, due to a wrong value on TAURI property from window object. Fixing in this PR

Before:
Showing in Desktop:
![image](https://github.com/user-attachments/assets/a0e7c8c1-ae16-4d3c-8aa6-0fe051c800d7)

After:
Not showing in Desktop:
![image](https://github.com/user-attachments/assets/75d07cdf-4121-412c-aa4d-4093229a36ce)

Still showing in Web:
![image](https://github.com/user-attachments/assets/57df49da-7bcd-4b4e-bb47-e8fbec04ea24)


### Which issue(s) this PR fixes 🔨

-   Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
