### PR TITLE
fix(iOS): Avoid zoom on iOS mobile app when tap on input elements

### DIFF
--- a/src/lib/elements/Input/Input.svelte
+++ b/src/lib/elements/Input/Input.svelte
@@ -237,6 +237,7 @@
 
         .input {
             background-color: transparent;
+            touch-action: manipulation;
             border: none;
             flex: 1;
             width: 100%;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Avoid zoom on iOS mobile app when tap on input elements

### Which issue(s) this PR fixes 🔨

-   Resolve #951 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
