### PR TITLE
fix(macos): camera/mic permission on macos build

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Request Microphone for Calling</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Request Microphone for Calling</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Request Camera for Calling</string>
+</dict>
+</plist>


### PR DESCRIPTION
### What this PR does 📖

- Adds permission for camera and mic on macos builds. Now it requests it properly

### Which issue(s) this PR fixes 🔨

- Partially addresses #883
